### PR TITLE
Fix cql-rb example

### DIFF
--- a/examples/cql-rb-wrapper.rb
+++ b/examples/cql-rb-wrapper.rb
@@ -38,27 +38,12 @@ class Client
   end
 
   def execute(*args)
-    promise = Ione::Promise.new
-    @session.execute_async(*args).on_complete do |e, v|
-      if e
-        promise.fail(e)
-      else
-        promise.fulfill(v)
-      end
-    end
-    promise.future
+    @session.execute(*args)
   end
 
   def prepare(statement, options = {})
-    promise = Ione::Promise.new
-    @session.prepare_async(statement, options).on_complete do |e, v|
-      if e
-        promise.fail(e)
-      else
-        promise.fulfill(PreparedStatement.new(self, v))
-      end
-    end
-    promise.future
+    s = @session.prepare(statement, options)
+    PreparedStatement.new(self, s)
   end
 
   def batch(type = :logged, options = {})
@@ -72,15 +57,7 @@ class Client
   end
 
   def close
-    promise = Ione::Promise.new
-    @session.close.on_complete do |e, v|
-      if e
-        promise.fail(e)
-      else
-        promise.fulfill(v)
-      end
-    end
-    promise.future
+    @session.close
   end
 end
 


### PR DESCRIPTION
The example uses private APIs (`Ione::CompletableFuture`) and present an async API when cql-rb's primary API is synchronous. `Client#close` also didn't work.

This changes the example to be synchronous.

I can provide a wrapper for the async API too, but to help with porting cql-rb applications this one will work better. It's not complete (it's missing `Client#use`, `PreparedStatement#batch`, for example), but it's probably good enough that people can add what they need themselves, it's just an example after all.
