### PR TITLE
simple client integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   matrix:
     - CASSANDRA_VERSION=2.1.0
     - CASSANDRA_VERSION=2.0.10
-    - CASSANDRA_VERSION=1.2.18
+    - CASSANDRA_VERSION=1.2.19
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'bundler/setup'
 
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
+require 'rake/testtask'
 
 ENV["FAIL_FAST"] ||= 'Y'
 
@@ -12,7 +13,7 @@ RSpec::Core::RakeTask.new(:rspec => :compile)
 Cucumber::Rake::Task.new(:cucumber => :compile)
 
 desc 'Run all tests'
-task :test => [:rspec, :cucumber]
+task :test => [:rspec, :integration, :cucumber]
 
 desc 'Generate documentation'
 task :docs do
@@ -33,4 +34,10 @@ else
   require 'rake/extensiontask'
 
   Rake::ExtensionTask.new('cassandra_murmur3')
+end
+
+Rake::TestTask.new(:integration => :compile) do |t|
+  t.libs.push "lib"
+  t.test_files = FileList['integration/*_test.rb']
+  t.verbose = true
 end

--- a/integration/integration_test_case.rb
+++ b/integration/integration_test_case.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2014 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require File.dirname(__FILE__) + '/../support/ccm.rb'
+require 'minitest/autorun'
+require 'cassandra'
+
+class IntegrationTestCase < MiniTest::Unit::TestCase
+  def setup
+    ccm_cluster
+  end
+
+  def ccm_cluster
+    $ccm_cluster ||= begin
+      cluster = CCM.setup_cluster(1, 1)
+      
+      at_exit do
+        $ccm_cluster.stop
+        $ccm_cluster = nil
+      end
+      
+      cluster
+    end
+  end
+
+  def teardown
+    cluster = Cassandra.connect
+    session = cluster.connect()
+
+    cluster.each_keyspace do |keyspace|
+      next if keyspace.name.start_with?('system')
+
+      session.execute("DROP KEYSPACE #{keyspace.name}")
+    end
+  end
+end

--- a/integration/session_test.rb
+++ b/integration/session_test.rb
@@ -1,0 +1,159 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2014 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require File.dirname(__FILE__) + '/integration_test_case.rb'
+
+class SessionTest < IntegrationTestCase
+
+  def test_initialially_nil
+    cluster = Cassandra.connect
+    session = cluster.connect()
+
+    assert_nil session.keyspace
+  end
+
+  def test_keyspaces_exist
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    results = session.execute("SELECT * FROM system.schema_keyspaces;")
+
+    refute_nil results
+  end
+
+  def test_use_keyspaces
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    session.execute("USE system")
+    assert_equal session.keyspace, "system"
+
+    session.execute("USE system_traces")
+    assert_equal session.keyspace, "system_traces"
+  end
+
+  def test_connect_with_keyspace
+    cluster = Cassandra.connect
+    session = cluster.connect("system")
+
+    assert_equal session.keyspace, "system"
+  end
+
+  def test_keyspace_creation
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    session.execute("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+    sleep(1)
+    assert cluster.has_keyspace?("simplex"), "Expected cluster to have keyspace 'simplex'"
+    
+    session.execute("USE simplex")
+    assert_equal session.keyspace, "simplex"
+  end
+
+  def test_schema_creation_and_insert
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    session.execute("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+    session.execute("USE simplex")
+
+    session.execute("CREATE TABLE users (user_id INT PRIMARY KEY, first VARCHAR, last VARCHAR, age INT);")
+    sleep(1)
+    assert cluster.keyspace("simplex").has_table?("users"), "Expected to keyspace 'simplex' to have table 'users'"
+
+    session.execute("INSERT INTO users (user_id, first, last, age) VALUES (0, 'John', 'Doe', 40);")
+    result = session.execute("SELECT * FROM users;").first
+
+    assert_equal result, {"user_id"=>0, "age"=>40, "first"=>"John", "last"=>"Doe"}
+  end
+
+  def test_schema_creation_and_insert_async
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    session.execute("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+    session.execute("USE simplex")
+
+    session.execute("CREATE TABLE users (user_id INT PRIMARY KEY, first VARCHAR, last VARCHAR, age INT);")
+    future = session.execute_async("INSERT INTO users (user_id, first, last, age) VALUES (0, 'John', 'Doe', 40);")
+    refute_nil future.get
+
+    future = session.execute_async("SELECT * FROM users;")
+    result = future.get.first
+    assert_equal result, {"user_id"=>0, "age"=>40, "first"=>"John", "last"=>"Doe"}
+  end
+
+  def test_prepared_statements
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    session.execute("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+    session.execute("USE simplex")
+    session.execute("CREATE TABLE users (user_id INT PRIMARY KEY, first VARCHAR, last VARCHAR, age INT);")
+
+    insert = session.prepare("INSERT INTO users (user_id, first, last, age) VALUES (?, ?, ?, ?);")
+    select = session.prepare("SELECT * FROM users;")
+    refute_nil insert
+    refute_nil select
+
+    session.execute(insert, 0, 'John', 'Doe', 40)
+    result = session.execute(select).first
+    assert_equal result, {"user_id"=>0, "age"=>40, "first"=>"John", "last"=>"Doe"}
+  end
+
+  def test_batch_statements
+    skip("Batch statements are only available in C* after 2.0") unless CCM.cassandra_version >= '2.0.0'
+
+    cluster = Cassandra.connect
+    session = cluster.connect()
+    session.execute("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+    session.execute("USE simplex")
+    session.execute("CREATE TABLE users (user_id BIGINT PRIMARY KEY, first VARCHAR, last VARCHAR, age BIGINT);")
+
+    # Simple statement
+    batch = session.batch do |b|
+      b.add("INSERT INTO users (user_id, first, last, age) VALUES (0, 'John', 'Doe', 40);")
+      b.add("INSERT INTO users (user_id, first, last, age) VALUES (1, 'Mary', 'Doe', 35);")
+      b.add("INSERT INTO users (user_id, first, last, age) VALUES (2, 'Agent', 'Smith', 32);")
+    end
+
+    session.execute(batch)
+    results = session.execute("SELECT * FROM users;")
+    assert_equal 3, results.size
+
+    # Parametrized simple statement
+    batch = session.batch do |b|
+      b.add("INSERT INTO users (user_id, first, last, age) VALUES (?, ?, ?, ?);", 3, 'Apache', 'Cassandra', 8)
+      b.add("INSERT INTO users (user_id, first, last, age) VALUES (?, ?, ?, ?);", 4, 'DataStax', 'Ruby-Driver', 1)
+      b.add("INSERT INTO users (user_id, first, last, age) VALUES (?, ?, ?, ?);", 5, 'Cassandra', 'Community', 8)
+    end
+
+    session.execute(batch)
+    results = session.execute("SELECT * FROM users;")
+    assert_equal 6, results.size
+
+    # Prepared statement
+    insert = session.prepare("INSERT INTO users (user_id, first, last, age) VALUES (?, ?, ?, ?);")
+    refute_nil insert
+
+    batch = session.batch do |b|
+      b.add(insert, 6, 'Joséphine', 'Baker', 108)
+      b.add(insert, 7, 'Stefan', 'Löfven', 57)
+      b.add(insert, 8, 'Mick', 'Jager', 71)
+    end
+
+    session.execute(batch)
+    results = session.execute("SELECT * FROM users;")
+    assert_equal 9, results.size
+  end
+end


### PR DESCRIPTION
Still need to add some sort of `@cassandra-version-specific @cassandra-version-2.0` to the C\* 2.0 features. Also will need to update rake task in Rakefile/Travis to include the new integration tests suite.
