### PR TITLE
Suppress warning "Comparable#== will no more rescue exceptions of #<=> in the next release."

### DIFF
--- a/lib/cassandra/time_uuid.rb
+++ b/lib/cassandra/time_uuid.rb
@@ -33,6 +33,7 @@ module Cassandra
     end
 
     def <=>(other)
+      return nil unless other.kind_of?(Cassandra::Uuid)
       c = self.value <=> other.value
       return c if c == 0
       self.time_bits <=> other.time_bits

--- a/spec/cassandra/time_uuid_spec.rb
+++ b/spec/cassandra/time_uuid_spec.rb
@@ -54,6 +54,12 @@ module Cassandra
         y = Uuid.new(x.value)
         x.should == y
       end
+
+      it 'allows comparison of TimeUUID and nil' do
+        x = generator.next
+        y = nil
+        lambda { x.should_not == y }.should_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Hi, thank you for your nice gem.

Unfortunately, `Comparable#==` will no more rescue exception in future release.
Thus `timeuuid == nil` raises undefined method exception.
This warning shows in ruby 2.2.0-preview1.

I try to write patch for this problem.
How about this?

see also: https://bugs.ruby-lang.org/issues/7688
