### PR TITLE
Cql scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 /.sass-cache
 /venv
 /lib/cassandra_murmur3.*
+/lib/cql_scanner.*
+/ext/cql_scanner/cql_scanner.c
+/ext/cql_scanner/CqlScannerService.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 script: bundle exec rake test
 bundler_args: --without development docs
 before_install:
-  - sudo apt-get install -y python-pip
+  - sudo apt-get install -y python-pip ragel
   - sudo pip install virtualenv
   - virtualenv venv
   - source venv/bin/activate

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :development do
     gem 'guard'
     gem 'guard-nanoc'
   end
+
+  gem 'cliver'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'snappy',        :group => [:development, :test]
 gem 'lz4-ruby',      :group => [:development, :test]
 gem 'rake-compiler', :group => [:development, :test]
+gem 'cliver',        :group => [:development, :test]
 
 group :development do
   platforms :mri_19 do
@@ -12,8 +13,6 @@ group :development do
     gem 'guard'
     gem 'guard-nanoc'
   end
-
-  gem 'cliver'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     childprocess (0.5.3)
       ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.1)
+    cliver (0.3.2)
     coderay (1.1.0)
     colored (1.2)
     compass (1.0.1)
@@ -136,6 +137,7 @@ DEPENDENCIES
   bootstrap-sass
   bundler (~> 1.6)
   cassandra-driver!
+  cliver
   compass
   cucumber
   ditaarb

--- a/ext/cql_scanner/extconf.rb
+++ b/ext/cql_scanner/extconf.rb
@@ -1,0 +1,2 @@
+require 'mkmf'
+create_makefile('cql_scanner')

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -414,6 +414,9 @@ require 'cassandra/util'
 # murmur3 hash extension
 require 'cassandra_murmur3'
 
+# cql scanner extension
+require 'cql_scanner'
+
 module Cassandra
   # @private
   Io = Ione::Io

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -414,8 +414,9 @@ require 'cassandra/util'
 # murmur3 hash extension
 require 'cassandra_murmur3'
 
-# cql scanner extension
+# cql scanner
 require 'cql_scanner'
+require 'cassandra/cql/type_guesser'
 
 module Cassandra
   # @private

--- a/lib/cassandra/cql/type_guesser.rb
+++ b/lib/cassandra/cql/type_guesser.rb
@@ -1,0 +1,200 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2014 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Cassandra
+  module CQL
+    class TypeGuesser
+      def initialize(cluster_schema)
+        @schema  = cluster_schema
+        @scanner = Scanner.new(self)
+        reset
+      end
+
+      def guess(cql, current_keyspace)
+        @keyspace = @schema.keyspace(current_keyspace)
+
+        @scanner.scan(cql)
+
+        (@state == :done) ? @typehints : nil
+      ensure
+        reset
+      end
+
+      def mark_keyspace(value)
+        @keyspace = @schema.keyspace(value)
+      end
+
+      def mark_table(value)
+        if @keyspace
+          @table = @keyspace.table(value)
+        end
+        @state = :columns
+      end
+
+      def mark_limit(value)
+        @state = :limit if @table
+      end
+
+      def mark_column(value)
+        if @state == :columns
+          @columns << value
+        end
+      end
+
+      def mark_literal(value)
+        @columns.shift if @state == :columns
+      end
+
+      def mark_positional_argument(value)
+        case @state
+        when :columns
+          name   = @columns.shift
+          column = nil
+          column = @table.column(name) if @table
+
+          if column
+            @typehints << column.type
+          else
+            @typehints << nil
+          end
+        when :limit
+          @typehints << :int
+        end
+      end
+
+      def mark_named_argument(value)
+        case @state
+        when :columns
+          column = @table.column(@columns.shift)
+
+          if column
+            @typehints << column.type
+          else
+            @typehints << nil
+          end
+        when :limit
+          @typehints << :int
+        end
+      end
+
+      def mark_select(value)
+      end
+
+      def mark_delete(value)
+      end
+
+      def mark_from(value)
+      end
+
+      def mark_update(value)
+      end
+
+      def mark_insert(value)
+      end
+
+      def mark_order(value)
+      end
+
+      def mark_in(value)
+      end
+
+      def mark_and(value)
+      end
+
+      def mark_writetime(value)
+      end
+
+      def mark_ttl(value)
+      end
+
+      def mark_now(value)
+      end
+
+      def mark_date_of(value)
+      end
+
+      def mark_min_timeuuid(value)
+      end
+
+      def mark_max_timeuuid(value)
+      end
+
+      def mark_unix_timestamp_of(value)
+      end
+
+      def mark_token(value)
+      end
+
+      def mark_function(value)
+      end
+
+      def mark_alias(value)
+      end
+
+      def mark_all(value)
+      end
+
+      def mark_count(value)
+      end
+
+      def mark_where(value)
+      end
+
+      def mark_order_by(value)
+      end
+
+      def mark_allow_filtering(value)
+      end
+
+      def mark_exists(value)
+      end
+
+      def mark_timestamp(value)
+      end
+
+      def mark_if(value)
+      end
+
+      def mark_operator(value)
+      end
+
+      def mark_property(value)
+      end
+
+      def mark_star(value)
+      end
+
+      def mark_values(value)
+      end
+
+      def mark_eof
+        @state = :done
+      end
+
+      private
+
+      def reset
+        @state     = :init
+        @table     = nil
+        @keyspace  = nil
+        @columns   = []
+        @typehints = []
+      end
+    end
+  end
+end

--- a/ragel/cql.rl
+++ b/ragel/cql.rl
@@ -1,3 +1,17 @@
+// Copyright 2013-2014 DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 %%{
   machine cql;
 

--- a/ragel/cql.rl
+++ b/ragel/cql.rl
@@ -1,0 +1,236 @@
+%%{
+  machine cql;
+
+  # Tokens
+  T_QUESTION_MARK = '?';
+  T_PAREN_OPEN    = '(';
+  T_PAREN_CLOSE   = ')';
+  T_STAR          = '*';
+  T_COMA          = ',';
+  T_COLON         = ':';
+  T_DOT           = '.';
+  T_BRACKET_OPEN  = '[';
+  T_BRACKET_CLOSE = ']';
+  T_BRACE_OPEN    = '{';
+  T_BRACE_CLOSE   = '}';
+  T_QUOTE         = "'";
+  T_DOUBLE_QUOTE  = '"';
+  T_DASH          = '-';
+  T_UNDERSCORE    = '_';
+  T_TRUE          = 'true'i;
+  T_FALSE         = 'false'i;
+  T_NULL          = 'null'i;
+  T_HEX           = '0x';
+  T_EQUAL         = '=';
+  T_LESS          = '<';
+  T_GREATER       = '>';
+  T_LESS_EQUAL    = '<=';
+  T_GREATER_EQUAL = '>=';
+  T_ONE           = '1';
+  T_PLUS          = '+';
+  T_MINUS         = '-';
+
+  # Keywords
+  K_SELECT          = 'select'i;
+  K_FROM            = 'from'i;
+  K_WHERE           = 'where'i;
+  K_IN              = 'in'i;
+  K_AND             = 'and'i;
+  K_ORDER_BY        = 'order'i space+ 'by'i;
+  K_ASC             = 'asc'i;
+  K_DESC            = 'desc'i;
+  K_LIMIT           = 'limit'i;
+  K_ALLOW           = 'allow'i;
+  K_ALLOW_FILTERING = K_ALLOW space+ 'filtering'i;
+  K_DISTINCT        = 'distinct'i;
+  K_COUNT           = 'count'i;
+  K_AS              = 'as'i;
+  K_WRITETIME       = 'writetime'i;
+  K_TTL             = 'ttl'i;
+  K_NOW             = 'now'i;
+  K_DELETE          = 'delete'i;
+  K_USING           = 'using'i;
+  K_TIMESTAMP       = 'timestamp'i;
+  K_USING_TIMESTAMP = K_USING space+ K_TIMESTAMP;
+  K_SET             = 'set'i;
+  K_IF              = 'if'i;
+  K_EXISTS          = 'exists'i;
+  K_UPDATE          = 'update'i;
+  K_INSERT          = 'insert'i;
+  K_INTO            = 'into'i;
+  K_VALUES          = 'values'i;
+  K_NOT             = 'not'i;
+  K_NOT_EXISTS      = K_NOT space* K_EXISTS;
+  K_DATE_OF         = 'dateOf';
+  K_MIN_TIMEUUID    = 'minTimeuuid';
+  K_MAX_TIMEUUID    = 'maxTimeuuid';
+  K_UNIX_TIMESTAMP  = 'unixTimestampOf';
+  K_TOKEN           = 'token';
+
+  # Reserved keywords
+  keyword           = K_SELECT
+                    | K_FROM
+                    | K_WHERE
+                    | K_IN
+                    | K_AND
+                    | K_ORDER_BY
+                    | K_ASC
+                    | K_DESC
+                    | K_LIMIT
+                    | K_ALLOW
+                    | K_DELETE
+                    | K_USING
+                    | K_IF
+                    ;
+
+  # Identifier
+  identifier        = (alpha (alpha | digit | T_UNDERSCORE)**)
+                    | T_DOUBLE_QUOTE (any -- T_DOUBLE_QUOTE | T_DOUBLE_QUOTE{2})** T_DOUBLE_QUOTE
+                    ;
+
+  # Appears in various lists
+  enumerator = space* T_COMA space*;
+
+  # Values
+  string            = T_QUOTE (any -- T_QUOTE | '\\\'')** T_QUOTE;
+  integer           = T_DASH? digit+;
+  float             = T_DASH? digit+ T_DOT digit+;
+  uuid              = xdigit{8} T_DASH xdigit{4} T_DASH xdigit{4} T_DASH xdigit{4} T_DASH xdigit{12};
+  boolean           = T_TRUE | T_FALSE;
+  blob              = T_HEX xdigit+;
+  nil               = T_NULL;
+  list              = T_BRACKET_OPEN >{ fcall skip_list; };
+  map_set           = T_BRACE_OPEN >{ fcall skip_map_set; };
+
+  # Function args
+  function_args     = T_PAREN_OPEN >{ fcall skip_args; };
+
+  # Function calls
+  count             = K_COUNT           space* function_args;
+  writetime         = K_WRITETIME       space* function_args;
+  ttl               = K_TTL             space* function_args;
+  now               = K_NOW             space* function_args;
+  date_of           = K_DATE_OF         space* function_args;
+  min_timeuuid      = K_MIN_TIMEUUID    space* function_args;
+  max_timeuuid      = K_MAX_TIMEUUID    space* function_args;
+  unix_timestamp_of = K_UNIX_TIMESTAMP  space* function_args;
+  token             = K_TOKEN           space* function_args;
+  custom_function   = (identifier T_COLON{2})? (identifier - (K_COUNT | K_WRITETIME | K_TTL | K_NOW | K_DATE_OF | K_MIN_TIMEUUID | K_MAX_TIMEUUID | K_UNIX_TIMESTAMP | K_TOKEN)) space* function_args;
+
+  # Simple values
+  simple   = string
+           | integer
+           | float
+           | uuid
+           | boolean
+           | blob
+           | nil
+           ;
+
+  # Complex values
+  complex  = list
+           | map_set
+           ;
+
+  # Function calls
+  function = writetime
+           | ttl
+           | now
+           | date_of
+           | min_timeuuid
+           | max_timeuuid
+           | unix_timestamp_of
+           | token
+           | custom_function
+           ;
+
+  # Literal values and function calls
+  literal  = simple
+           | complex
+           | function
+           ;
+
+  # Literals or argument markers
+  value      = literal            >literal_start %literal_end
+             | T_QUESTION_MARK    >positional_argument_start %positional_argument_end
+             | T_COLON identifier >named_argument_start %named_argument_end
+             ;
+  value_list = T_PAREN_OPEN value (enumerator value)* T_PAREN_CLOSE;
+
+  column   = (identifier - keyword) >column_start %column_end;
+
+  operator = (T_EQUAL | T_LESS | T_GREATER | T_LESS_EQUAL | T_GREATER_EQUAL) >operator_start %operator_end;
+
+  skip_args    := (function_args | ^T_PAREN_CLOSE)* T_PAREN_CLOSE >{ fret; };
+  skip_list    := (list | map_set | ^T_BRACKET_CLOSE)* T_BRACKET_CLOSE >{ fret; };
+  skip_map_set := (list | map_set | ^T_BRACE_CLOSE)* T_BRACE_CLOSE >{ fret; };
+
+  keyspace_name = identifier >keyspace_start %keyspace_end T_DOT;
+  table_name    = keyspace_name? identifier >table_start %table_end;
+
+  # SELECT
+  order            = (K_ASC | K_DESC);
+  ordering         = (identifier - keyword) (space+ order)?;
+  order_clause     = ordering (enumerator ordering)*;
+  column_list      = T_PAREN_OPEN column (enumerator column)* T_PAREN_CLOSE;
+  select_condition = column space* operator space* value
+                   | column space+ K_IN >in_start %in_end space+ T_PAREN_OPEN (value (enumerator value)*)? T_PAREN_CLOSE
+                   | column_list space* operator space* value_list
+                   | column_list space+ K_IN >in_start %in_end space+ value_list
+                   | token space* operator space* value
+                   ;
+  select_where     = select_condition (space+ K_AND >and_start %and_end space+ select_condition)*;
+  selector         = column
+                   | writetime         >writetime_start %writetime_end
+                   | ttl               >ttl_start %ttl_end
+                   | now               >now_start %now_end
+                   | date_of           >date_of_start %date_of_end
+                   | min_timeuuid      >min_timeuuid_start %min_timeuuid_end
+                   | max_timeuuid      >max_timeuuid_start %max_timeuuid_end
+                   | unix_timestamp_of >unix_timestamp_of_start %unix_timestamp_of_end
+                   | token             >token_start %token_end
+                   | custom_function   >function_start %function_end
+                   ;
+  alias            = space+ K_AS space+ identifier;
+  selector_list    = (selector alias? (enumerator selector alias?)*)
+                   | T_STAR >star_start %star_end
+                   ;
+  select_clause    = count >count_start %count_end alias?
+                   | K_DISTINCT? selector_list
+                   ;
+  limit            = integer            >literal_start %literal_end
+                   | T_QUESTION_MARK    >positional_argument_start %positional_argument_end
+                   | T_COLON identifier >named_argument_start %named_argument_end
+                   ;
+  select_stmt      = K_SELECT >select_start %select_end space+ select_clause space+ K_FROM >from_start %from_end space+ table_name (space+ K_WHERE >where_start %where_end space+ select_where)? (space+ K_ORDER_BY space+ order_clause)? (space+ K_LIMIT >limit_start %limit_end space+ limit)? (space+ K_ALLOW_FILTERING)?;
+
+  # DELETE
+  deletor          = (identifier - keyword) (T_BRACKET_OPEN simple T_BRACKET_CLOSE)?;
+  delete_if        = deletor space* T_EQUAL >operator_start %operator_end space* value;
+  delete_if_clause = K_EXISTS >exists_start %exists_end
+                   | delete_if (space+ K_AND >and_start %and_end space+ delete_if)*
+                   ;
+  delete_condition = column space* T_EQUAL >operator_start %operator_end space* value
+                   | column space+ K_IN >in_start %in_end space+ value_list
+                   ;
+  delete_where     = delete_condition (space+ K_AND >and_start %and_end space+ delete_condition)*;
+  deletor_list     = deletor (enumerator deletor)*;
+  delete_stmt      = K_DELETE >delete_start %delete_end (space+ deletor_list)? space+ K_FROM >from_start %from_end space+ table_name (space+ K_USING_TIMESTAMP space+ integer >timestamp_start %timestamp_end)? space+ K_WHERE >where_start %where_end space+ delete_where (space+ K_IF >if_start %if_end space+ delete_if_clause)?;
+
+  # UPDATE
+  assigner         = column (T_BRACKET_OPEN simple >property_start %property_end T_BRACKET_CLOSE)?;
+  update_assign    = assigner space* T_EQUAL >operator_start %operator_end space* value
+                   | (identifier - keyword) space* T_EQUAL space* (identifier - keyword) space* (T_PLUS | T_MINUS) space* (integer | list | map_set)
+                   | (identifier - keyword) space* T_EQUAL space* (identifier - keyword) space* T_PLUS space* map_set
+                   ;
+  option           = K_TIMESTAMP space+ integer
+                   | K_TTL space+ integer
+                   ;
+  using_clause     = K_USING space+ option (space+ K_AND space+ option)*;
+  update_stmt      = K_UPDATE >update_start %update_end space+ table_name (space+ using_clause)? space+ K_SET space+ update_assign (enumerator update_assign)* space+ K_WHERE >where_start %where_end space+ delete_where (space+ K_IF >if_start %if_end space+ delete_if_clause)?;
+
+  # INSERT
+  insert_stmt      = K_INSERT >insert_start %insert_end space+ K_INTO space+ table_name space+ column_list space+ K_VALUES >values_start %values_end space+ value_list (space+ K_IF >if_start %if_end space+ K_NOT_EXISTS >not_exists_start %not_exists_end)? (space+ using_clause)?;
+
+  main := select_stmt | delete_stmt | update_stmt | insert_stmt;
+}%%

--- a/ragel/scanner_c.rl
+++ b/ragel/scanner_c.rl
@@ -1,0 +1,301 @@
+// Copyright 2013-2014 DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+%%{
+  machine scanner;
+
+  action literal_start             { MARK(literal); }
+  action literal_end               { EMIT(literal); }
+  action positional_argument_start { MARK(positional_argument); }
+  action positional_argument_end   { EMIT(positional_argument); }
+  action named_argument_start      { MARK(named_argument); }
+  action named_argument_end        { EMIT(named_argument); }
+  action column_start              { MARK(column); }
+  action column_end                { EMIT(column); }
+  action keyspace_start            { MARK(keyspace); }
+  action keyspace_end              { EMIT(keyspace); }
+  action table_start               { MARK(table); }
+  action table_end                 { EMIT(table); }
+  action order_start               { MARK(order); }
+  action order_end                 { EMIT(order); }
+  action in_start                  { MARK(in); }
+  action in_end                    { EMIT(in); }
+  action and_start                 { MARK(and); }
+  action and_end                   { EMIT(and); }
+  action writetime_start           { MARK(writetime); }
+  action writetime_end             { EMIT(writetime); }
+  action ttl_start                 { MARK(ttl); }
+  action ttl_end                   { EMIT(ttl); }
+  action now_start                 { MARK(now); }
+  action now_end                   { EMIT(now); }
+  action date_of_start             { MARK(date_of); }
+  action date_of_end               { EMIT(date_of); }
+  action min_timeuuid_start        { MARK(min_timeuuid); }
+  action min_timeuuid_end          { EMIT(min_timeuuid); }
+  action max_timeuuid_start        { MARK(max_timeuuid); }
+  action max_timeuuid_end          { EMIT(max_timeuuid); }
+  action unix_timestamp_of_start   { MARK(unix_timestamp_of); }
+  action unix_timestamp_of_end     { EMIT(unix_timestamp_of); }
+  action token_start               { MARK(token); }
+  action token_end                 { EMIT(token); }
+  action function_start            { MARK(function); }
+  action function_end              { EMIT(function); }
+  action alias_start               { MARK(alias); }
+  action alias_end                 { EMIT(alias); }
+  action all_start                 { MARK(all); }
+  action all_end                   { EMIT(all); }
+  action count_start               { MARK(count); }
+  action count_end                 { EMIT(count); }
+  action select_start              { MARK(select); }
+  action select_end                { EMIT(select); }
+  action from_start                { MARK(from); }
+  action from_end                  { EMIT(from); }
+  action where_start               { MARK(where); }
+  action where_end                 { EMIT(where); }
+  action order_by_start            { MARK(order_by); }
+  action order_by_end              { EMIT(order_by); }
+  action limit_start               { MARK(limit); }
+  action limit_end                 { EMIT(limit); }
+  action allow_filtering_start     { MARK(allow_filtering); }
+  action allow_filtering_end       { EMIT(allow_filtering); }
+  action exists_start              { MARK(exists); }
+  action exists_end                { EMIT(exists); }
+  action delete_start              { MARK(delete); }
+  action delete_end                { EMIT(delete); }
+  action timestamp_start           { MARK(timestamp); }
+  action timestamp_end             { EMIT(timestamp); }
+  action if_start                  { MARK(if); }
+  action if_end                    { EMIT(if); }
+  action operator_start            { MARK(operator); }
+  action operator_end              { EMIT(operator); }
+  action property_start            { MARK(property); }
+  action property_end              { EMIT(property); }
+  action update_start              { MARK(update); }
+  action update_end                { EMIT(update); }
+  action star_start                { MARK(star); }
+  action star_end                  { EMIT(star); }
+  action insert_start              { MARK(insert); }
+  action insert_end                { EMIT(insert); }
+  action values_start              { MARK(values); }
+  action values_end                { EMIT(values); }
+  action not_exists_start          { MARK(not_exists); }
+  action not_exists_end            { EMIT(not_exists); }
+
+  prepush {
+    if (top >= ssize) {
+      ssize = ssize + RAGEL_STACK_INCR;
+      stack = realloc(stack, sizeof(int) * ssize);
+    }
+  }
+
+  postpop {
+    if (ssize - top >= RAGEL_STACK_INCR) {
+      ssize = ssize - RAGEL_STACK_INCR;
+      stack = realloc(stack, sizeof(int) * ssize);
+    }
+  }
+
+  include cql "cql.rl";
+}%%
+
+#include <assert.h>
+#include <ruby.h>
+
+#if defined(_WIN32)
+#include <stddef.h>
+#endif
+
+#ifdef HAVE_RUBY_RE_H
+#include <ruby/re.h>
+#else
+#include <re.h>
+#endif
+
+#define DATA_GET(FROM, TYPE, NAME) \
+  Data_Get_Struct(FROM, TYPE, NAME); \
+  if (NAME == NULL) { \
+    rb_raise(rb_eArgError, "NULL found for " # NAME " when it shouldn't be."); \
+  }
+
+/* The initial size of the Ragel stack. */
+#define RAGEL_STACK_SIZE 5
+
+/* The amount by which the Ragel stack will be increased or decreased. */
+#define RAGEL_STACK_INCR 10
+
+typedef struct scanner_state_s {
+  const char* start_literal;
+  const char* start_positional_argument;
+  const char* start_named_argument;
+  const char* start_column;
+  const char* start_keyspace;
+  const char* start_table;
+  const char* start_order;
+  const char* start_in;
+  const char* start_and;
+  const char* start_writetime;
+  const char* start_ttl;
+  const char* start_now;
+  const char* start_date_of;
+  const char* start_min_timeuuid;
+  const char* start_max_timeuuid;
+  const char* start_unix_timestamp_of;
+  const char* start_token;
+  const char* start_function;
+  const char* start_alias;
+  const char* start_all;
+  const char* start_count;
+  const char* start_select;
+  const char* start_from;
+  const char* start_where;
+  const char* start_order_by;
+  const char* start_limit;
+  const char* start_allow_filtering;
+  const char* start_exists;
+  const char* start_delete;
+  const char* start_timestamp;
+  const char* start_if;
+  const char* start_operator;
+  const char* start_property;
+  const char* start_update;
+  const char* start_star;
+  const char* start_insert;
+  const char* start_values;
+  const char* start_not_exists;
+} scanner_state;
+
+#define MARK(M) (scanner->start_##M = p)
+#define EMIT(M) (rb_funcall(listener, rb_intern("mark_" #M), 1, rb_str_new(scanner->start_##M, (p - scanner->start_##M))))
+
+%% write data;
+
+static void
+scanner_init(scanner_state *scanner) {
+  assert(scanner);
+
+  scanner->start_literal = NULL;
+  scanner->start_positional_argument = NULL;
+  scanner->start_named_argument = NULL;
+  scanner->start_column = NULL;
+  scanner->start_keyspace = NULL;
+  scanner->start_table = NULL;
+  scanner->start_order = NULL;
+  scanner->start_in = NULL;
+  scanner->start_and = NULL;
+  scanner->start_writetime = NULL;
+  scanner->start_ttl = NULL;
+  scanner->start_now = NULL;
+  scanner->start_date_of = NULL;
+  scanner->start_min_timeuuid = NULL;
+  scanner->start_max_timeuuid = NULL;
+  scanner->start_unix_timestamp_of = NULL;
+  scanner->start_token = NULL;
+  scanner->start_function = NULL;
+  scanner->start_alias = NULL;
+  scanner->start_all = NULL;
+  scanner->start_count = NULL;
+  scanner->start_select = NULL;
+  scanner->start_from = NULL;
+  scanner->start_where = NULL;
+  scanner->start_order_by = NULL;
+  scanner->start_limit = NULL;
+  scanner->start_allow_filtering = NULL;
+  scanner->start_exists = NULL;
+  scanner->start_delete = NULL;
+  scanner->start_timestamp = NULL;
+  scanner->start_if = NULL;
+  scanner->start_operator = NULL;
+  scanner->start_property = NULL;
+  scanner->start_update = NULL;
+  scanner->start_star = NULL;
+  scanner->start_insert = NULL;
+  scanner->start_values = NULL;
+  scanner->start_not_exists = NULL;
+}
+
+static VALUE
+cScanner_scan(VALUE self, VALUE input)
+{
+  char *data;
+  size_t len;
+  const char *p, *pe, *eof;
+  int cs, top;
+  unsigned int ssize;
+  int *stack;
+  VALUE listener;
+  scanner_state *scanner;
+
+  scanner = NULL;
+  DATA_GET(self, scanner_state, scanner);
+
+  /* Reset scanner by re-initializing the whole thing */
+  scanner_init(scanner);
+
+  ssize    = RAGEL_STACK_SIZE;
+  stack    = malloc(sizeof(int) * ssize);
+  data     = RSTRING_PTR(input);
+  len      = RSTRING_LEN(input);
+  listener = rb_iv_get(self, "@listener");
+  cs       = 0;
+  top      = 0;
+  p        = data;
+  pe       = data + len;
+  eof      = pe;
+
+  assert(*pe == '\0' && "pointer does not end on NULL");
+
+  %% write init;
+  %% write exec;
+
+  assert(p <= pe && "data overflow after parsing execute");
+
+  if (p == eof) {
+    rb_funcall(listener, rb_intern("mark_eof"), 0);
+  }
+
+  return self;
+}
+
+static VALUE
+cScanner_alloc(VALUE klass)
+{
+  VALUE obj;
+  scanner_state *state = ALLOC(scanner_state);
+
+  obj = Data_Wrap_Struct(klass, NULL, -1, state);
+
+  return obj;
+}
+
+static VALUE
+cScanner_init(VALUE self, VALUE listener)
+{
+  rb_iv_set(self, "@listener", listener);
+
+  return self;
+}
+
+void
+Init_cql_scanner()
+{
+  VALUE mCassandra, mCQL, cScanner;
+
+  mCassandra = rb_define_module_under(rb_cObject, "Cassandra");
+  mCQL       = rb_define_module_under(mCassandra, "CQL");
+  cScanner   = rb_define_class_under(mCQL, "Scanner", rb_cObject);
+
+  rb_define_alloc_func(cScanner, cScanner_alloc);
+  rb_define_method(cScanner, "initialize", cScanner_init, 1);
+  rb_define_method(cScanner, "scan", cScanner_scan, 1);
+}

--- a/ragel/scanner_java.rl
+++ b/ragel/scanner_java.rl
@@ -1,0 +1,223 @@
+// Copyright 2013-2014 DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+%%{
+  machine scanner;
+
+  action literal_start             { literal_start = p; }
+  action literal_end               { listener.callMethod(context, "mark_literal", RubyString.newString(context.runtime, data, literal_start, p - literal_start)); }
+  action positional_argument_start { positional_argument_start = p; }
+  action positional_argument_end   { listener.callMethod(context, "mark_positional_argument", RubyString.newString(context.runtime, data, positional_argument_start, p - positional_argument_start)); }
+  action named_argument_start      { named_argument_start = p; }
+  action named_argument_end        { listener.callMethod(context, "mark_named_argument", RubyString.newString(context.runtime, data, named_argument_start, p - named_argument_start)); }
+  action column_start              { column_start = p; }
+  action column_end                { listener.callMethod(context, "mark_column", RubyString.newString(context.runtime, data, column_start, p - column_start)); }
+  action keyspace_start            { keyspace_start = p; }
+  action keyspace_end              { listener.callMethod(context, "mark_keyspace", RubyString.newString(context.runtime, data, keyspace_start, p - keyspace_start)); }
+  action table_start               { table_start = p; }
+  action table_end                 { listener.callMethod(context, "mark_table", RubyString.newString(context.runtime, data, table_start, p - table_start)); }
+  action order_start               { order_start = p; }
+  action order_end                 { listener.callMethod(context, "mark_order", RubyString.newString(context.runtime, data, order_start, p - order_start)); }
+  action in_start                  { in_start = p; }
+  action in_end                    { listener.callMethod(context, "mark_in", RubyString.newString(context.runtime, data, in_start, p - in_start)); }
+  action and_start                 { and_start = p; }
+  action and_end                   { listener.callMethod(context, "mark_and", RubyString.newString(context.runtime, data, and_start, p - and_start)); }
+  action writetime_start           { writetime_start = p; }
+  action writetime_end             { listener.callMethod(context, "mark_writetime", RubyString.newString(context.runtime, data, writetime_start, p - writetime_start)); }
+  action ttl_start                 { ttl_start = p; }
+  action ttl_end                   { listener.callMethod(context, "mark_ttl", RubyString.newString(context.runtime, data, ttl_start, p - ttl_start)); }
+  action now_start                 { now_start = p; }
+  action now_end                   { listener.callMethod(context, "mark_now", RubyString.newString(context.runtime, data, now_start, p - now_start)); }
+  action date_of_start             { date_of_start = p; }
+  action date_of_end               { listener.callMethod(context, "mark_date_of", RubyString.newString(context.runtime, data, date_of_start, p - date_of_start)); }
+  action min_timeuuid_start        { min_timeuuid_start = p; }
+  action min_timeuuid_end          { listener.callMethod(context, "mark_min_timeuuid", RubyString.newString(context.runtime, data, min_timeuuid_start, p - min_timeuuid_start)); }
+  action max_timeuuid_start        { max_timeuuid_start = p; }
+  action max_timeuuid_end          { listener.callMethod(context, "mark_max_timeuuid", RubyString.newString(context.runtime, data, max_timeuuid_start, p - max_timeuuid_start)); }
+  action unix_timestamp_of_start   { unix_timestamp_of_start = p; }
+  action unix_timestamp_of_end     { listener.callMethod(context, "mark_unix_timestamp_of", RubyString.newString(context.runtime, data, unix_timestamp_of_start, p - unix_timestamp_of_start)); }
+  action token_start               { token_start = p; }
+  action token_end                 { listener.callMethod(context, "mark_token", RubyString.newString(context.runtime, data, token_start, p - token_start)); }
+  action function_start            { function_start = p; }
+  action function_end              { listener.callMethod(context, "mark_function", RubyString.newString(context.runtime, data, function_start, p - function_start)); }
+  action alias_start               { alias_start = p; }
+  action alias_end                 { listener.callMethod(context, "mark_alias", RubyString.newString(context.runtime, data, alias_start, p - alias_start)); }
+  action all_start                 { all_start = p; }
+  action all_end                   { listener.callMethod(context, "mark_all", RubyString.newString(context.runtime, data, all_start, p - all_start)); }
+  action count_start               { count_start = p; }
+  action count_end                 { listener.callMethod(context, "mark_count", RubyString.newString(context.runtime, data, count_start, p - count_start)); }
+  action select_start              { select_start = p; }
+  action select_end                { listener.callMethod(context, "mark_select", RubyString.newString(context.runtime, data, select_start, p - select_start)); }
+  action from_start                { from_start = p; }
+  action from_end                  { listener.callMethod(context, "mark_from", RubyString.newString(context.runtime, data, from_start, p - from_start)); }
+  action where_start               { where_start = p; }
+  action where_end                 { listener.callMethod(context, "mark_where", RubyString.newString(context.runtime, data, where_start, p - where_start)); }
+  action order_by_start            { order_by_start = p; }
+  action order_by_end              { listener.callMethod(context, "mark_order_by", RubyString.newString(context.runtime, data, order_by_start, p - order_by_start)); }
+  action limit_start               { limit_start = p; }
+  action limit_end                 { listener.callMethod(context, "mark_limit", RubyString.newString(context.runtime, data, limit_start, p - limit_start)); }
+  action allow_filtering_start     { allow_filtering_start = p; }
+  action allow_filtering_end       { listener.callMethod(context, "mark_allow_filtering", RubyString.newString(context.runtime, data, allow_filtering_start, p - allow_filtering_start)); }
+  action exists_start              { exists_start = p; }
+  action exists_end                { listener.callMethod(context, "mark_exists", RubyString.newString(context.runtime, data, exists_start, p - exists_start)); }
+  action delete_start              { delete_start = p; }
+  action delete_end                { listener.callMethod(context, "mark_delete", RubyString.newString(context.runtime, data, delete_start, p - delete_start)); }
+  action timestamp_start           { timestamp_start = p; }
+  action timestamp_end             { listener.callMethod(context, "mark_timestamp", RubyString.newString(context.runtime, data, timestamp_start, p - timestamp_start)); }
+  action if_start                  { if_start = p; }
+  action if_end                    { listener.callMethod(context, "mark_if", RubyString.newString(context.runtime, data, if_start, p - if_start)); }
+  action operator_start            { operator_start = p; }
+  action operator_end              { listener.callMethod(context, "mark_operator", RubyString.newString(context.runtime, data, operator_start, p - operator_start)); }
+  action property_start            { property_start = p; }
+  action property_end              { listener.callMethod(context, "mark_property", RubyString.newString(context.runtime, data, property_start, p - property_start)); }
+  action update_start              { update_start = p; }
+  action update_end                { listener.callMethod(context, "mark_update", RubyString.newString(context.runtime, data, update_start, p - update_start)); }
+  action star_start                { star_start = p; }
+  action star_end                  { listener.callMethod(context, "mark_star", RubyString.newString(context.runtime, data, star_start, p - star_start)); }
+  action insert_start              { insert_start = p; }
+  action insert_end                { listener.callMethod(context, "mark_insert", RubyString.newString(context.runtime, data, insert_start, p - insert_start)); }
+  action values_start              { values_start = p; }
+  action values_end                { listener.callMethod(context, "mark_values", RubyString.newString(context.runtime, data, values_start, p - values_start)); }
+  action not_exists_start          { not_exists_start = p; }
+  action not_exists_end            { listener.callMethod(context, "mark_not_exists", RubyString.newString(context.runtime, data, not_exists_start, p - not_exists_start)); }
+
+  prepush {
+    if (top >= ssize) {
+      ssize = ssize + 10;
+      stack = Arrays.copyOf(stack, ssize);
+    }
+  }
+
+  postpop {
+    if (ssize - top >= 10) {
+      ssize = ssize - 10;
+      stack = Arrays.copyOf(stack, ssize);
+    }
+  }
+
+  include cql "cql.rl";
+}%%
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.jruby.Ruby;
+import org.jruby.RubyString;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyModule;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.load.BasicLibraryService;
+
+public class CqlScannerService implements BasicLibraryService
+{
+    public boolean basicLoad(final Ruby runtime) throws IOException
+    {
+        RubyModule cassandra = runtime.defineModule("Cassandra");
+        RubyModule cql       = runtime.defineModuleUnder("CQL", cassandra);
+        RubyClass  scanner   = cql.defineClassUnder("Scanner", runtime.getObject(), new ObjectAllocator() {
+            public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {
+                return new Scanner(runtime, rubyClass);
+            }
+        });
+
+        scanner.defineAnnotatedMethods(Scanner.class);
+
+        return true;
+    }
+
+    @JRubyClass(name="Scanner")
+    public static class Scanner extends RubyObject
+    {
+        %% write data;
+
+        private IRubyObject listener;
+
+        public Scanner(Ruby runtime, RubyClass metaClass)
+        {
+            super(runtime, metaClass);
+        }
+
+        @JRubyMethod(name="initialize", required = 1)
+        protected IRubyObject initialize(ThreadContext context, IRubyObject listener)
+        {
+            this.listener = listener;
+
+            return this;
+        }
+
+        @JRubyMethod(name="scan", required = 1, argTypes = {RubyString.class})
+        public IRubyObject scan(ThreadContext context, IRubyObject object)
+        {
+            byte[] data = object.convertToString().getBytes();
+            int cs, p = 0, pe = data.length, top = 0;
+            int eof = pe;
+            int   ssize = 5;
+            int[] stack = new int[ssize];
+
+            int literal_start = 0;
+            int positional_argument_start = 0;
+            int named_argument_start = 0;
+            int column_start = 0;
+            int keyspace_start = 0;
+            int table_start = 0;
+            int order_start = 0;
+            int in_start = 0;
+            int and_start = 0;
+            int writetime_start = 0;
+            int ttl_start = 0;
+            int now_start = 0;
+            int date_of_start = 0;
+            int min_timeuuid_start = 0;
+            int max_timeuuid_start = 0;
+            int unix_timestamp_of_start = 0;
+            int token_start = 0;
+            int function_start = 0;
+            int alias_start = 0;
+            int all_start = 0;
+            int count_start = 0;
+            int select_start = 0;
+            int from_start = 0;
+            int where_start = 0;
+            int order_by_start = 0;
+            int limit_start = 0;
+            int allow_filtering_start = 0;
+            int exists_start = 0;
+            int delete_start = 0;
+            int timestamp_start = 0;
+            int if_start = 0;
+            int operator_start = 0;
+            int property_start = 0;
+            int update_start = 0;
+            int star_start = 0;
+            int insert_start = 0;
+            int values_start = 0;
+            int not_exists_start = 0;
+
+            %% write init;
+            %% write exec;
+
+            if (p == eof) {
+                listener.callMethod(context, "mark_eof");
+            }
+
+            return this;
+        }
+    }
+}

--- a/ragel/scanner_ruby.rl
+++ b/ragel/scanner_ruby.rl
@@ -1,3 +1,21 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2014 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
 module Cassandra
   module CQL
     class Scanner

--- a/ragel/scanner_ruby.rl
+++ b/ragel/scanner_ruby.rl
@@ -1,0 +1,111 @@
+module Cassandra
+  module CQL
+    class Scanner
+      %%{
+        machine scanner;
+
+        action literal_start             { literal_s = p; }
+        action literal_end               { @listener.mark_literal(cql[literal_s...p]); }
+        action positional_argument_start { positional_argument_s = p; }
+        action positional_argument_end   { @listener.mark_positional_argument(cql[positional_argument_s...p]); }
+        action named_argument_start      { named_argument_s = p; }
+        action named_argument_end        { @listener.mark_named_argument(cql[named_argument_s...p]); }
+        action column_start              { column_s = p; }
+        action column_end                { @listener.mark_column(cql[column_s...p]); }
+        action keyspace_start            { keyspace_s = p; }
+        action keyspace_end              { @listener.mark_keyspace(cql[keyspace_s...p]); }
+        action table_start               { table_s = p; }
+        action table_end                 { @listener.mark_table(cql[table_s...p]); }
+        action order_start               { order_s = p; }
+        action order_end                 { @listener.mark_order(cql[order_s...p]); }
+        action in_start                  { in_s = p; }
+        action in_end                    { @listener.mark_in(cql[in_s...p]); }
+        action and_start                 { and_s = p; }
+        action and_end                   { @listener.mark_and(cql[and_s...p]); }
+        action writetime_start           { writetime_s = p; }
+        action writetime_end             { @listener.mark_writetime(cql[writetime_s...p]); }
+        action ttl_start                 { ttl_s = p; }
+        action ttl_end                   { @listener.mark_ttl(cql[ttl_s...p]); }
+        action now_start                 { now_s = p; }
+        action now_end                   { @listener.mark_now(cql[now_s...p]); }
+        action date_of_start             { date_of_s = p; }
+        action date_of_end               { @listener.mark_date_of(cql[date_of_s...p]); }
+        action min_timeuuid_start        { min_timeuuid_s = p; }
+        action min_timeuuid_end          { @listener.mark_min_timeuuid(cql[min_timeuuid_s...p]); }
+        action max_timeuuid_start        { max_timeuuid_s = p; }
+        action max_timeuuid_end          { @listener.mark_max_timeuuid(cql[max_timeuuid_s...p]); }
+        action unix_timestamp_of_start   { unix_timestamp_of_s = p; }
+        action unix_timestamp_of_end     { @listener.mark_unix_timestamp_of(cql[unix_timestamp_of_s...p]); }
+        action token_start               { token_s = p; }
+        action token_end                 { @listener.mark_token(cql[token_s...p]); }
+        action function_start            { function_s = p; }
+        action function_end              { @listener.mark_function(cql[function_s...p]); }
+        action alias_start               { alias_s = p; }
+        action alias_end                 { @listener.mark_alias(cql[alias_s...p]); }
+        action all_start                 { all_s = p; }
+        action all_end                   { @listener.mark_all(cql[all_s...p]); }
+        action count_start               { count_s = p; }
+        action count_end                 { @listener.mark_count(cql[count_s...p]); }
+        action select_start              { select_s = p; }
+        action select_end                { @listener.mark_select(cql[select_s...p]); }
+        action from_start                { from_s = p; }
+        action from_end                  { @listener.mark_from(cql[from_s...p]); }
+        action where_start               { where_s = p; }
+        action where_end                 { @listener.mark_where(cql[where_s...p]); }
+        action order_by_start            { order_by_s = p; }
+        action order_by_end              { @listener.mark_order_by(cql[order_by_s...p]); }
+        action limit_start               { limit_s = p; }
+        action limit_end                 { @listener.mark_limit(cql[limit_s...p]); }
+        action allow_filtering_start     { allow_filtering_s = p; }
+        action allow_filtering_end       { @listener.mark_allow_filtering(cql[allow_filtering_s...p]); }
+        action exists_start              { exists_s = p; }
+        action exists_end                { @listener.mark_exists(cql[exists_s...p]); }
+        action delete_start              { delete_s = p; }
+        action delete_end                { @listener.mark_delete(cql[delete_s...p]); }
+        action timestamp_start           { timestamp_s = p; }
+        action timestamp_end             { @listener.mark_timestamp(cql[timestamp_s...p]); }
+        action if_start                  { if_s = p; }
+        action if_end                    { @listener.mark_if(cql[if_s...p]); }
+        action operator_start            { operator_s = p; }
+        action operator_end              { @listener.mark_operator(cql[operator_s...p]); }
+        action property_start            { property_s = p; }
+        action property_end              { @listener.mark_property(cql[property_s...p]); }
+        action update_start              { update_s = p; }
+        action update_end                { @listener.mark_update(cql[update_s...p]); }
+        action star_start                { star_s = p; }
+        action star_end                  { @listener.mark_star(cql[star_s...p]); }
+        action insert_start              { insert_s = p; }
+        action insert_end                { @listener.mark_insert(cql[insert_s...p]); }
+        action values_start              { values_s = p; }
+        action values_end                { @listener.mark_values(cql[values_s...p]); }
+        action not_exists_start          { not_exists_s = p; }
+        action not_exists_end            { @listener.mark_not_exists(cql[not_exists_s...p]); }
+
+        include cql "cql.rl";
+      }%%
+
+      def initialize(listener)
+        @listener = listener
+
+        %% write data;
+      end
+
+      def scan(cql)
+        data  = cql.bytes.to_a
+        eof   = cql.bytesize
+        stack = []
+
+        %% write init;
+        %% write exec;
+
+        @listener.mark_eof if p == eof
+
+        self
+      end
+
+      def inspect
+        "#<#{self.class.name}:0x#{self.object_id.to_s(16)}>"
+      end
+    end
+  end
+end

--- a/spec/cassandra/cql/scanner_spec.rb
+++ b/spec/cassandra/cql/scanner_spec.rb
@@ -1,0 +1,270 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2014 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require 'spec_helper'
+
+class Listener
+  attr_reader :tokens
+
+  def initialize
+    @tokens = []
+  end
+
+  def mark_literal(value)
+    @tokens << [:literal, value]
+  end
+
+  def mark_positional_argument(value)
+    @tokens << [:positional_argument, value]
+  end
+
+  def mark_named_argument(value)
+    @tokens << [:named_argument, value]
+  end
+
+  def mark_column(value)
+    @tokens << [:column, value]
+  end
+
+  def mark_keyspace(value)
+    @tokens << [:keyspace, value]
+  end
+
+  def mark_table(value)
+    @tokens << [:table, value]
+  end
+
+  def mark_order(value)
+    @tokens << [:order, value]
+  end
+
+  def mark_in(value)
+    @tokens << [:in, value]
+  end
+
+  def mark_and(value)
+    @tokens << [:and, value]
+  end
+
+  def mark_writetime(value)
+    @tokens << [:writetime, value]
+  end
+
+  def mark_ttl(value)
+    @tokens << [:ttl, value]
+  end
+
+  def mark_now(value)
+    @tokens << [:now, value]
+  end
+
+  def mark_date_of(value)
+    @tokens << [:date_of, value]
+  end
+
+  def mark_min_timeuuid(value)
+    @tokens << [:min_timeuuid, value]
+  end
+
+  def mark_max_timeuuid(value)
+    @tokens << [:max_timeuuid, value]
+  end
+
+  def mark_unix_timestamp_of(value)
+    @tokens << [:unix_timestamp_of, value]
+  end
+
+  def mark_token(value)
+    @tokens << [:token, value]
+  end
+
+  def mark_function(value)
+    @tokens << [:function, value]
+  end
+
+  def mark_alias(value)
+    @tokens << [:alias, value]
+  end
+
+  def mark_all(value)
+    @tokens << [:all, value]
+  end
+
+  def mark_count(value)
+    @tokens << [:count, value]
+  end
+
+  def mark_select(value)
+    @tokens << [:select, value]
+  end
+
+  def mark_from(value)
+    @tokens << [:from, value]
+  end
+
+  def mark_where(value)
+    @tokens << [:where, value]
+  end
+
+  def mark_order_by(value)
+    @tokens << [:order_by, value]
+  end
+
+  def mark_limit(value)
+    @tokens << [:limit, value]
+  end
+
+  def mark_allow_filtering(value)
+    @tokens << [:allow_filtering, value]
+  end
+
+  def mark_exists(value)
+    @tokens << [:exists, value]
+  end
+
+  def mark_delete(value)
+    @tokens << [:delete, value]
+  end
+
+  def mark_timestamp(value)
+    @tokens << [:timestamp, value]
+  end
+
+  def mark_if(value)
+    @tokens << [:if, value]
+  end
+
+  def mark_operator(value)
+    @tokens << [:operator, value]
+  end
+
+  def mark_property(value)
+    @tokens << [:property, value]
+  end
+
+  def mark_update(value)
+    @tokens << [:update, value]
+  end
+
+  def mark_star(value)
+    @tokens << [:star, value]
+  end
+
+  def mark_insert(value)
+    @tokens << [:insert, value]
+  end
+
+  def mark_values(value)
+    @tokens << [:values, value]
+  end
+
+  def mark_eof
+    @tokens << [:eof]
+  end
+end
+
+module Cassandra
+  module CQL
+    describe(Scanner) do
+      let(:listener) { Listener.new }
+      subject { Scanner.new(listener) }
+
+      describe('#scan') do
+        [
+          [
+            "SELECT * FROM users", [
+              [:select, 'SELECT'],
+              [:star, '*'],
+              [:from, 'FROM'],
+              [:table, 'users'],
+              [:eof]
+            ]
+          ],
+          [
+            "UPDATE users SET username='bulat', email='bulat.shakirzyanov@datastax.com', age = 28 WHERE id = ?", [
+              [:update, 'UPDATE'],
+              [:table, 'users'],
+              [:column, 'username'],
+              [:operator, '='],
+              [:literal, "'bulat'"],
+              [:column, 'email'],
+              [:operator, '='],
+              [:literal, "'bulat.shakirzyanov@datastax.com'"],
+              [:column, 'age'],
+              [:operator, '='],
+              [:literal, '28'],
+              [:where, 'WHERE'],
+              [:column, 'id'],
+              [:operator, '='],
+              [:positional_argument, '?'],
+              [:eof]
+            ]
+          ],
+          [
+            "SELECT username, email FROM users WHERE id = ?", [
+              [:select, 'SELECT'],
+              [:column, 'username'],
+              [:column, 'email'],
+              [:from, 'FROM'],
+              [:table, 'users'],
+              [:where, 'WHERE'],
+              [:column, 'id'],
+              [:operator, '='],
+              [:positional_argument, '?'],
+              [:eof]
+            ]
+          ],
+          [
+            "DELETE username, email FROM simplex.users WHERE id = ?", [
+              [:delete, 'DELETE'],
+              [:from, 'FROM'],
+              [:keyspace, 'simplex'],
+              [:table, 'users'],
+              [:where, 'WHERE'],
+              [:column, 'id'],
+              [:operator, '='],
+              [:positional_argument, '?'],
+              [:eof]
+            ]
+          ],
+          [
+            "INSERT INTO NerdMovies (movie, director, main_actor, year) VALUES ('Serenity', 'Joss Whedon', 'Nathan Fillion', 2005) USING TTL 86400", [
+              [:insert, 'INSERT'],
+              [:table, 'NerdMovies'],
+              [:column, 'movie'],
+              [:column, 'director'],
+              [:column, 'main_actor'],
+              [:column, 'year'],
+              [:values, 'VALUES'],
+              [:literal, "'Serenity'"],
+              [:literal, "'Joss Whedon'"],
+              [:literal, "'Nathan Fillion'"],
+              [:literal, "2005"],
+              [:eof]
+            ]
+          ]
+        ].each do |(statement, tokens)|
+          it "correctly scans #{statement.inspect}" do
+            subject.scan(statement)
+            expect(listener.tokens).to eq(tokens)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassandra/cql/type_guesser_spec.rb
+++ b/spec/cassandra/cql/type_guesser_spec.rb
@@ -1,0 +1,157 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2014 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require 'spec_helper'
+
+module Cassandra
+  module CQL
+    describe(TypeGuesser) do
+      let(:schema) { Cluster::Schema.new(Cluster::Schema::TypeParser.new) }
+
+      let(:host)      { Cassandra::Host.new('127.0.0.1', nil, nil, nil, '2.0.10') }
+      let(:keyspaces) {
+        [
+          {
+            "keyspace_name"    => "simplex",
+            "durable_writes"   => true,
+            "strategy_class"   =>"org.apache.cassandra.locator.SimpleStrategy",
+            "strategy_options" => "{\"replication_factor\":\"3\"}"
+          }
+        ]
+      }
+      let(:tables) {
+        [
+          {
+            "keyspace_name"               => "simplex",
+            "columnfamily_name"           => "users",
+            "bloom_filter_fp_chance"      => 0.01,
+            "caching"                     => "KEYS_ONLY",
+            "column_aliases"              => "[]",
+            "comment"                     => "",
+            "compaction_strategy_class"   => "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy",
+            "compaction_strategy_options" => "{}",
+            "comparator"                  => "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type)",
+            "compression_parameters"      => "{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}",
+            "default_time_to_live"        => 0, "default_validator"=>"org.apache.cassandra.db.marshal.BytesType",
+            "dropped_columns"             => nil,
+            "gc_grace_seconds"            => 864000,
+            "index_interval"              => 128,
+            "is_dense"                    => false,
+            "key_aliases"                 => "[\"id\"]",
+            "key_validator"               => "org.apache.cassandra.db.marshal.UUIDType",
+            "local_read_repair_chance"    => 0.1,
+            "max_compaction_threshold"    => 32,
+            "memtable_flush_period_in_ms" => 0,
+            "min_compaction_threshold"    => 4,
+            "populate_io_cache_on_flush"  => false,
+            "read_repair_chance"          => 0.0,
+            "replicate_on_write"          => true,
+            "speculative_retry"           => "99.0PERCENTILE",
+            "subcomparator"               => nil,
+            "type"                        => "Standard",
+            "value_alias"                 => nil
+          }
+        ]
+      }
+
+      let(:columns) {
+        [
+          {
+            "keyspace_name"     => "simplex",
+            "columnfamily_name" => "users",
+            "column_name"       => "age",
+            "component_index"   => 0,
+            "index_name"        => nil,
+            "index_options"     => nil,
+            "index_type"        => nil,
+            "type"              => "regular",
+            "validator"         => "org.apache.cassandra.db.marshal.Int32Type"
+          },
+          {
+            "keyspace_name"     => "simplex",
+            "columnfamily_name" => "users",
+            "column_name"       => "email",
+            "component_index"   => 0,
+            "index_name"        => nil,
+            "index_options"     => nil,
+            "index_type"        => nil,
+            "type"              => "regular",
+            "validator"         => "org.apache.cassandra.db.marshal.UTF8Type"
+          },
+          {
+            "keyspace_name"     => "simplex",
+            "columnfamily_name" => "users",
+            "column_name"       => "id",
+            "component_index"   => nil,
+            "index_name"        => nil,
+            "index_options"     => nil,
+            "index_type"        => nil,
+            "type"              => "partition_key",
+            "validator"         => "org.apache.cassandra.db.marshal.UUIDType"
+          },
+          {
+            "keyspace_name"     => "simplex",
+            "columnfamily_name" => "users",
+            "column_name"       => "username",
+            "component_index"   => 0,
+            "index_name"        => nil,
+            "index_options"     => nil,
+            "index_type"        => nil,
+            "type"              => "regular",
+            "validator"         => "org.apache.cassandra.db.marshal.UTF8Type"
+          }
+        ]
+      }
+
+      subject { TypeGuesser.new(schema) }
+
+      before do
+        schema.update_keyspaces(host, keyspaces, tables, columns)
+      end
+
+      describe('#guess') do
+        [
+          [
+            "SELECT * FROM users",
+            []
+          ],
+          [
+            "UPDATE users SET username='bulat', email='bulat.shakirzyanov@datastax.com', age = 28 WHERE id = ?",
+            [:uuid]
+          ],
+          [
+            "SELECT username, email FROM users WHERE id = ?",
+            [:uuid]
+          ],
+          [
+            "DELETE username, email FROM simplex.users WHERE id = ?",
+            [:uuid]
+          ],
+          [
+            "INSERT INTO users (username, email, id, age) VALUES (?, ?, ?, ?) USING TTL 86400",
+            [:text, :text, :uuid, :int]
+          ]
+        ].each do |(cql, typehints)|
+          it "works on #{cql.inspect}" do
+            expect(subject.guess(cql, 'simplex')).to eq(typehints)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this is a concept pull request, that adds intelligent type resolution for parameterized and named arguments in simple queries.

this is achieved by parsing cql grammar and using schema metadata to find correct argument types based on columns that those arguments operate on.

this proposal might never get merged as it can be considered out of scope for driver's functionality, however, I'm opening this to gauge interest and get opinions on this feature.
