### PR TITLE
Fixing a method call in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ __Note__: JRuby 1.6 is not officially supported, although 1.6.8 should work.
 ```ruby
 require 'cassandra'
 
-cluster = Cassandra.cluster # connects to localhost by default
+cluster = Cassandra.connect # connects to localhost by default
 
 cluster.each_host do |host| # automatically discovers all peers
   puts "Host #{host.ip}: id=#{host.id} datacenter=#{host.datacenter} rack=#{host.rack}"


### PR DESCRIPTION
Fixing the method to be called on Cassandra object on line #38. Referring this http://datastax.github.io/ruby-driver/#quick-start for making this change.
