### PR TITLE
Added escaping to keyspace name in Client#use_keyspace, Client#switch_keyspace

### DIFF
--- a/lib/cassandra/client/client.rb
+++ b/lib/cassandra/client/client.rb
@@ -458,7 +458,7 @@ module Cassandra
         return Ione::Future.failed(InvalidKeyspaceNameError.new(%("#{keyspace}" is not a valid keyspace name))) unless keyspace =~ /^\w[\w\d_]*$|^"\w[\w\d_]*"$/
 
         futures = connections.map do |connection|
-          request = Protocol::QueryRequest.new("USE #{keyspace}", nil, nil, :one)
+          request = Protocol::QueryRequest.new("USE #{Util.escape_name(keyspace)}", nil, nil, :one)
           @request_runner.execute(connection, request).map(connection)
         end
         Ione::Future.all(*futures)

--- a/lib/cassandra/cluster/client.rb
+++ b/lib/cassandra/cluster/client.rb
@@ -752,7 +752,7 @@ module Cassandra
 
         return pending_switch || Ione::Future.resolved if pending_keyspace == keyspace
 
-        request = Protocol::QueryRequest.new("USE #{keyspace}", nil, nil, :one)
+        request = Protocol::QueryRequest.new("USE #{Util.escape_name(keyspace)}", nil, nil, :one)
 
         f = connection.send_request(request, timeout).map do |r|
           case r
@@ -760,7 +760,7 @@ module Cassandra
             @keyspace = r.keyspace
             nil
           when Protocol::ErrorResponse
-            raise r.to_error(Statements::Simple.new("USE #{keyspace}"))
+            raise r.to_error(Statements::Simple.new("USE #{Util.escape_name(keyspace)}"))
           else
             raise Errors::ProtocolError, "Unexpected response #{r.inspect}"
           end


### PR DESCRIPTION
Enables support of keyspace names containing capital letters.
