### PR TITLE
Cassandra::Future::Factory.all should return future

### DIFF
--- a/lib/cassandra/future.rb
+++ b/lib/cassandra/future.rb
@@ -201,6 +201,7 @@ module Cassandra
             end
           end
         end
+        promise.future
       end
     end
 


### PR DESCRIPTION
Missing return of promise's future in all.

BTW. We found Cassandra::Future.promise useful, can it be reintroduced?
