### PR TITLE
Microseconds precision on bytes_to_timestamp

### DIFF
--- a/lib/cassandra/protocol/type_converter.rb
+++ b/lib/cassandra/protocol/type_converter.rb
@@ -339,7 +339,7 @@ module Cassandra
 
       def timestamp_to_bytes(buffer, value, size_bytes)
         if value
-          ms = (value.to_f * 1000).to_i
+          ms = (value.to_r.to_f * 1000).to_i
           size_to_bytes(buffer, 8, size_bytes)
           buffer.append_long(ms)
         else

--- a/lib/cassandra/protocol/type_converter.rb
+++ b/lib/cassandra/protocol/type_converter.rb
@@ -188,7 +188,11 @@ module Cassandra
       def bytes_to_timestamp(buffer, size_bytes)
         return nil unless read_size(buffer, size_bytes)
         timestamp = buffer.read_long
-        Time.at(timestamp/1000.0)
+
+        seconds = timestamp / 1_000
+        microsenconds = (timestamp % 1_000) * 1_000
+
+        Time.at(seconds, microsenconds)
       end
 
       def bytes_to_varchar(buffer, size_bytes)

--- a/spec/cassandra/protocol/responses/rows_result_response_spec.rb
+++ b/spec/cassandra/protocol/responses/rows_result_response_spec.rb
@@ -213,7 +213,7 @@ module Cassandra
           end
 
           it 'decodes TIMESTAMP as a Time' do
-            response.rows.first['timestamp_column'].should == Time.at(1358013521.123)
+            response.rows.first['timestamp_column'].should == Time.at(1358013521, 123_000)
           end
 
           it 'decodes UUID as a Uuid' do

--- a/spec/cassandra/protocol/type_converter_spec.rb
+++ b/spec/cassandra/protocol/type_converter_spec.rb
@@ -100,6 +100,15 @@ module Cassandra
             end
           end
         end
+
+        context("when decoding timestamp") do
+          it "maintains microsenconds precision" do
+            time = Time.now
+            encoded = converter.to_bytes(buffer, :timestamp, time)
+            decoded = converter.from_bytes(encoded, :timestamp)
+            expect((decoded.to_r.to_f * 1000).to_i).to eq((time.to_r.to_f * 1000).to_i)
+          end
+        end
       end
     end
   end

--- a/spec/cassandra/protocol/type_converter_spec.rb
+++ b/spec/cassandra/protocol/type_converter_spec.rb
@@ -103,10 +103,14 @@ module Cassandra
 
         context("when decoding timestamp") do
           it "maintains microsenconds precision" do
-            time = Time.now
-            encoded = converter.to_bytes(buffer, :timestamp, time)
-            decoded = converter.from_bytes(encoded, :timestamp)
-            expect((decoded.to_r.to_f * 1000).to_i).to eq((time.to_r.to_f * 1000).to_i)
+            time        = Time.now
+            encoded     = converter.to_bytes(buffer, :timestamp, time)
+            decoded     = converter.from_bytes(encoded, :timestamp)
+
+            decoded_int = (decoded.to_r.to_f * 1000).to_i
+            time_int    = (time.to_r.to_f * 1000).to_i
+
+            expect(decoded_int).to eq(time_int)
           end
         end
       end


### PR DESCRIPTION
This PR fixes the microseconds error on type conversion when converting bytes to timestamps.

It makes use of the `Time#to_r` for converting from `timestamp_to_bytes` when storing the data and the second parameter (microseconds) to the `Time#at` method.

There's a [test case](https://github.com/threefunkymonkeys/ruby-driver/blob/master/spec/cassandra/protocol/type_converter_spec.rb#L105) to make sure the conversion is done properly

The fix is based in the [bug report in ruby-lang.org](https://bugs.ruby-lang.org/issues/10135#note-7).