### PR TITLE
[RUBY-30] Jenkins CI fixes

### DIFF
--- a/features/error_handling/request_execution.feature
+++ b/features/error_handling/request_execution.feature
@@ -154,7 +154,11 @@ Feature: Request Execution Errors
     When it is executed
     Then its output should contain:
       """
-      Cassandra::Errors::IOError: Could not connect to 127.0.0.1:9042 within 1s
+      Cassandra::Errors::NoHostsAvailable: All attempted hosts failed
+      """
+    And its output should contain:
+      """
+      Cassandra::Errors::TimeoutError: Timed out
       """
 
   Scenario: Executing a statement when all hosts are down

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -61,3 +61,7 @@ end
 After('@netblock') do
   @cluster.unblock_nodes
 end
+
+at_exit do
+  CCM.stop_and_remove
+end


### PR DESCRIPTION
Refactored `block_node` and `unblock_nodes` in ccm.rb to use the new CCM commands `pause` and `resume`, and dropped the use of the Firewall class. Also refactored the scenario `Connecting to unreachable cluster` with updated error message.