### PR TITLE
[RUBY-93] don't create connections recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Breaking Changes:
 
 * Splat style positional arguments support, deprecated in 2.0.0, has been dropped
 
+Bug Fixes:
+
+* [RUBY-93] Reconnection can overflow the stack
+
 # 2.0.1
 
 Bug Fixes:


### PR DESCRIPTION
removed recursive reconnection, schedule partially-connected hosts to fully reconnect in the background, raise error when all hosts are partially-connected