### PR TITLE
Slow queries logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,3 +167,6 @@ DEPENDENCIES
   simplecov
   snappy
   yard
+
+BUNDLED WITH
+   1.10.4

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -535,6 +535,7 @@ require 'cassandra/compression'
 require 'cassandra/protocol'
 require 'cassandra/auth'
 require 'cassandra/null_logger'
+require 'cassandra/slow_queries_logger'
 
 require 'cassandra/executors'
 require 'cassandra/future'

--- a/lib/cassandra/cluster/connector.rb
+++ b/lib/cassandra/cluster/connector.rb
@@ -121,7 +121,7 @@ module Cassandra
             connection.to_io.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 0)
           end
 
-          Protocol::CqlProtocolHandler.new(connection, @reactor, @connection_options.protocol_version, @connection_options.compressor, @connection_options.heartbeat_interval, @connection_options.idle_timeout)
+          Protocol::CqlProtocolHandler.new(connection, @reactor, @connection_options.protocol_version, Cassandra.queries_logger_for(@logger), @connection_options.compressor, @connection_options.heartbeat_interval, @connection_options.idle_timeout)
         end.flat_map do |connection|
           f = request_options(connection)
           f = f.flat_map do |options|

--- a/lib/cassandra/slow_queries_logger.rb
+++ b/lib/cassandra/slow_queries_logger.rb
@@ -1,0 +1,49 @@
+module Cassandra
+
+  class SlowQueriesLogger
+
+    def initialize(logger, threshold_ms = 250)
+      @threshold_ms = threshold_ms
+      @logger = logger
+      @times = {}
+      @requests = {}
+      @logger.debug "Initialized slow queries logger with threshold: #{threshold_ms} ms."
+    end
+
+    def start(id, request)
+      @times[id] = Time.now
+      @requests[id] = request.respond_to?(:cql) ? request.cql : request.to_s
+    end
+
+    def finish(id)
+      delta = ((Time.now - @times[id]) * 1_000).round 3
+      if delta > @threshold_ms
+        @logger.warn "***** SLOW QUERY!! *****"
+        @logger.warn "#{@requests[id]} took #{delta} ms."
+      end
+    end
+
+    def delete(id)
+      @times.delete id
+      @requests.delete id
+    end
+  end
+
+  class NullQueriesLogger
+    def initialize ; end
+
+    def start(id, request) ; end
+
+    def finish(id) ; end
+
+    def delete(id) ; end
+  end
+
+  def self.queries_logger_for(logger)
+    if logger.is_a? NullLogger
+      NullQueriesLogger.new
+    else
+      SlowQueriesLogger.new logger
+    end
+  end
+end

--- a/spec/cassandra/protocol/cql_protocol_handler_spec.rb
+++ b/spec/cassandra/protocol/cql_protocol_handler_spec.rb
@@ -23,7 +23,7 @@ module Cassandra
   module Protocol
     describe CqlProtocolHandler do
       let :protocol_handler do
-        described_class.new(connection, scheduler, 1)
+        described_class.new(connection, scheduler, 1, query_logger)
       end
 
       let :connection do
@@ -40,6 +40,10 @@ module Cassandra
 
       let :buffer do
         CqlByteBuffer.new
+      end
+
+      let :query_logger do
+        Cassandra.queries_logger_for NullLogger.new
       end
 
       before do
@@ -171,7 +175,7 @@ module Cassandra
 
         context 'when a compressor is specified' do
           let :protocol_handler do
-            described_class.new(connection, scheduler, 1, compressor)
+            described_class.new(connection, scheduler, 1, query_logger, compressor)
           end
 
           let :compressor do
@@ -211,7 +215,7 @@ module Cassandra
 
         context 'when a protocol version is specified' do
           let :protocol_handler do
-            described_class.new(connection, scheduler, 7)
+            described_class.new(connection, scheduler, 7, query_logger)
           end
 
           it 'sets the protocol version in the header' do

--- a/spec/slow_queries_logger_spec.rb
+++ b/spec/slow_queries_logger_spec.rb
@@ -1,0 +1,58 @@
+
+require 'spec_helper'
+
+module Cassandra
+  describe SlowQueriesLogger do
+    subject { described_class.new logger }
+
+    let(:req_id) { 1 }
+    let(:cql) { "SELECT * FROM here" }
+    let(:request) { double('request', cql: cql) }
+
+    let(:logger) { instance_double('Logger', warn: true, debug: true) }
+
+    describe '#start' do
+      it 'saves the start time' do
+        expect do
+          subject.start req_id, request
+        end.to change { subject.instance_variable_get(:@times).keys.count }.from(0).to 1
+      end
+
+      it 'saves the request' do
+        expect do
+          subject.start req_id, request
+        end.to change { subject.instance_variable_get(:@requests)[req_id] }.from(nil).to cql
+      end
+    end
+
+    describe '#finish' do
+      it 'logs if neccessary' do
+        subject.start req_id, request
+        sleep 0.3
+        expect(logger).to receive(:warn).twice
+        subject.finish req_id
+      end
+
+      it "doesn't log if not neccessary" do
+        subject.start req_id, request
+        expect(logger).to_not receive(:warn)
+        subject.finish req_id
+      end
+    end
+
+    describe '#delete' do
+      before { subject.start req_id, request }
+      it 'deletes the time record' do
+        expect do
+          subject.delete req_id
+        end.to change { subject.instance_variable_get(:@times).keys.count }.from(1).to 0
+      end
+
+      it 'deletes the request' do
+        expect do
+          subject.delete req_id
+        end.to change { subject.instance_variable_get(:@requests)[req_id] }.from(cql).to nil
+      end
+    end
+  end
+end

--- a/spec/slow_queries_logger_spec.rb
+++ b/spec/slow_queries_logger_spec.rb
@@ -54,5 +54,15 @@ module Cassandra
         end.to change { subject.instance_variable_get(:@requests)[req_id] }.from(cql).to nil
       end
     end
+
+    describe 'queries for logger method convenience' do
+      it 'returns a null queries logger if null logger is given' do
+        expect(Cassandra.queries_logger_for NullLogger.new).to be_a NullQueriesLogger
+      end
+
+      it 'returns a slow queries logger otherwise' do
+        expect(Cassandra.queries_logger_for Logger.new(STDOUT)).to be_a SlowQueriesLogger
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a little but useful feature which is found in other drivers (i.e: Java) which is the slow query logger.

The query logger works on the client side and hooks into the asynchronous logic of sending/receiving requests, timing them and showing an WARN into the configured logs with details of the query.