### PR TITLE
adding type_hints for simple statements, to override Util.guess_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+Features:
+
+* Add support for `type_hints` to override type-guessing for non-prepared statements.
+
 # 2.1.4
 
 Features:

--- a/lib/cassandra/execution/options.rb
+++ b/lib/cassandra/execution/options.rb
@@ -32,6 +32,8 @@ module Cassandra
       attr_reader :timeout
       # @return [Array] positional arguments for the statement
       attr_reader :arguments
+      # @return [Array] type hints for positional arguments for the statement
+      attr_reader :type_hints
 
       # @return [String] paging state
       #
@@ -56,6 +58,7 @@ module Cassandra
         serial_consistency = options[:serial_consistency]
         paging_state       = options[:paging_state]
         arguments          = options[:arguments]
+        type_hints         = options[:type_hints]
 
         Util.assert_one_of(CONSISTENCIES, consistency) { ":consistency must be one of #{CONSISTENCIES.inspect}, #{consistency.inspect} given" }
 
@@ -85,6 +88,12 @@ module Cassandra
           Util.assert_instance_of_one_of([::Array, ::Hash], arguments) { ":arguments must be an Array or a Hash, #{arguments.inspect} given" }
         end
 
+        if type_hints.nil?
+          type_hints = EMPTY_LIST
+        else
+          Util.assert_instance_of_one_of([::Array, ::Hash], type_hints) { ":type_hints must be an Array or a Hash, #{type_hints.inspect} given" }
+        end
+
         @consistency        = consistency
         @page_size          = page_size
         @trace              = !!trace
@@ -92,6 +101,7 @@ module Cassandra
         @serial_consistency = serial_consistency
         @paging_state       = paging_state
         @arguments          = arguments
+        @type_hints         = type_hints
       end
 
       # @return [Boolean] whether request tracing was enabled
@@ -107,7 +117,8 @@ module Cassandra
           other.timeout == @timeout &&
           other.serial_consistency == @serial_consistency &&
           other.paging_state == @paging_state &&
-          other.arguments == @arguments
+          other.arguments == @arguments &&
+          other.type_hints == @type_hints
       end
       alias :== :eql?
 
@@ -130,7 +141,8 @@ module Cassandra
           :trace              => @trace,
           :timeout            => @timeout,
           :serial_consistency => @serial_consistency,
-          :arguments          => @arguments || EMPTY_LIST
+          :arguments          => @arguments || EMPTY_LIST,
+          :type_hints         => @type_hints || EMPTY_LIST
         }
       end
     end

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -433,7 +433,7 @@ module Cassandra
         when 0x0020 then Types.list(read_type_v1(buffer))
         when 0x0021 then Types.map(read_type_v1(buffer), read_type_v1(buffer))
         when 0x0022 then Types.set(read_type_v1(buffer))
-        else 
+        else
           raise Errors::DecodingError, %(Unsupported column type: #{kind})
         end
       end

--- a/lib/cassandra/session.rb
+++ b/lib/cassandra/session.rb
@@ -57,6 +57,9 @@ module Cassandra
     #   initial request.
     # @option options [Array, Hash] :arguments (nil) positional or named
     #   arguments for the statement.
+    # @option options [Array, Hash] :type_hints (nil) override Util.guess_type to
+    #   determine the CQL type for an argument; nil elements will fall-back
+    #   to Util.guess_type.
     #
     # @see Cassandra.cluster Options that can be specified on the cluster-level
     #   and their default values.
@@ -80,7 +83,7 @@ module Cassandra
 
       case statement
       when ::String
-        @client.query(Statements::Simple.new(statement, options.arguments), options)
+        @client.query(Statements::Simple.new(statement, options.arguments, options.type_hints), options)
       when Statements::Simple
         @client.query(statement, options)
       when Statements::Prepared

--- a/lib/cassandra/statements/batch.rb
+++ b/lib/cassandra/statements/batch.rb
@@ -63,6 +63,8 @@ module Cassandra
       # @param args [Array, Hash] (nil) positional or named arguments to bind,
       #   must contain the same number of parameters as the number of positional
       #   (`?`) or named (`:name`) markers in the CQL passed.
+      # @param type_hints [Array, Hash] (nil) specified CQL types for positional
+      #   or named arguments to override type guessing.
       #
       # @note Positional arguments for simple statements are only supported
       #   starting with Apache Cassandra 2.0 and above.
@@ -71,12 +73,13 @@ module Cassandra
       #   starting with Apache Cassandra 2.1 and above.
       #
       # @return [self]
-      def add(statement, args = nil)
+      def add(statement, args = nil, type_hints = nil)
         args ||= EMPTY_LIST
+        type_hints ||= EMPTY_LIST
 
         case statement
         when String
-          @statements << Simple.new(statement, args)
+          @statements << Simple.new(statement, args, type_hints)
         when Prepared
           @statements << statement.bind(args)
         when Bound, Simple

--- a/lib/cassandra/statements/simple.rb
+++ b/lib/cassandra/statements/simple.rb
@@ -75,7 +75,7 @@ module Cassandra
 
         @cql          = cql
         @params       = params
-        @params_types = params.each_with_index.map {|value, index| (!type_hints.empty? && type_hints[index]) ? Types::Simple.new(type_hints[index]) : Util.guess_type(value)}
+        @params_types = params.each_with_index.map {|value, index| (!type_hints.empty? && type_hints[index] && type_hints[index].is_a?(Type)) ? type_hints[index] : Util.guess_type(value)}
         @params_names = params_names
       end
 

--- a/lib/cassandra/statements/simple.rb
+++ b/lib/cassandra/statements/simple.rb
@@ -33,7 +33,10 @@ module Cassandra
       attr_reader :params_names
 
       # @param cql [String] a cql statement
-      # @param params [Array] (nil) positional arguments for the query
+      # @param params [Array, Hash] (nil) positional or named arguments
+      #   for the query
+      # @param type_hints [Array, Hash] (nil) positional or named types
+      #   to override type guessing for the query
       #
       # @note Positional arguments for simple statements are only supported
       #   starting with Apache Cassandra 2.0 and above.
@@ -42,10 +45,11 @@ module Cassandra
       #   starting with Apache Cassandra 2.1 and above.
       #
       # @raise [ArgumentError] if cql statement given is not a String
-      def initialize(cql, params = nil)
+      def initialize(cql, params = nil, type_hints = nil)
         Util.assert_instance_of(::String, cql) { "cql must be a string, #{cql.inspect} given" }
 
         params ||= EMPTY_LIST
+
 
         if params.is_a?(::Hash)
           params_names = []
@@ -53,14 +57,25 @@ module Cassandra
             params_names << name
             params       << value
           end
+          if type_hints && !type_hints.empty?
+            Util.assert_instance_of(::Hash, type_hints) { "type_hints must be a Hash when using named params" }
+          end
         else
           Util.assert_instance_of(::Array, params) { "params must be an Array or a Hash, #{params.inspect} given" }
           params_names = EMPTY_LIST
         end
 
+        type_hints ||= EMPTY_LIST
+
+        if type_hints.is_a?(::Hash)
+          type_hints = params_names.map {|name| type_hints[name] }
+        else
+          Util.assert_instance_of(::Array, type_hints) { "type_hints must be an Array or a Hash, #{type_hints.inspect} given" }
+        end
+
         @cql          = cql
         @params       = params
-        @params_types = params.map {|value| Util.guess_type(value)}
+        @params_types = params.each_with_index.map {|value, index| (!type_hints.empty? && type_hints[index]) ? Types::Simple.new(type_hints[index]) : Util.guess_type(value)}
         @params_names = params_names
       end
 

--- a/spec/cassandra/session_spec.rb
+++ b/spec/cassandra/session_spec.rb
@@ -34,7 +34,7 @@ module Cassandra
             promise   = double('promise')
             statement = double('simple statement')
 
-            expect(Statements::Simple).to receive(:new).once.with(cql, EMPTY_LIST).and_return(statement)
+            expect(Statements::Simple).to receive(:new).once.with(cql, EMPTY_LIST, EMPTY_LIST).and_return(statement)
             expect(client).to receive(:query).once.with(statement, session_options).and_return(promise)
             expect(session.execute_async(cql)).to eq(promise)
           end
@@ -47,9 +47,22 @@ module Cassandra
             promise   = double('promise')
             statement = double('simple statement')
 
-            expect(Statements::Simple).to receive(:new).once.with(cql, [1]).and_return(statement)
+            expect(Statements::Simple).to receive(:new).once.with(cql, [1], []).and_return(statement)
             expect(client).to receive(:query).once.with(statement, session_options.override(arguments: [1])).and_return(promise)
             expect(session.execute_async(cql, arguments: [1])).to eq(promise)
+          end
+        end
+
+        context 'with arguments and type_hints' do
+          let(:cql) { 'SELECT * FROM songs WHERE id = ?' }
+
+          it 'sends query with a simple statement with parameters and type hints' do
+            promise   = double('promise')
+            statement = double('simple statement')
+
+            expect(Statements::Simple).to receive(:new).once.with(cql, [1], [:int]).and_return(statement)
+            expect(client).to receive(:query).once.with(statement, session_options.override(arguments: [1], type_hints: [:int])).and_return(promise)
+            expect(session.execute_async(cql, arguments: [1], type_hints: [:int])).to eq(promise)
           end
         end
 
@@ -61,7 +74,7 @@ module Cassandra
             promise   = double('promise')
             statement = double('simple statement')
 
-            expect(Statements::Simple).to receive(:new).once.with(cql, EMPTY_LIST).and_return(statement)
+            expect(Statements::Simple).to receive(:new).once.with(cql, EMPTY_LIST, EMPTY_LIST).and_return(statement)
             expect(client).to receive(:query).once.with(statement, session_options.override(options)).and_return(promise)
             expect(session.execute_async(cql, options)).to eq(promise)
           end


### PR DESCRIPTION
I've been using cql-rb, and in upgrading a project to use ruby-driver instead, noticed that there's no way to do a parameterized query (without preparing it) if the CQL type is `INT` instead of `BIGINT` (because of the way ruby-driver uses `Util.guess_type` to determine the CQL type for `Fixnum`)

This was possible in cql-rb with the `type_hints` option, so I thought I'd port that option over to the datastax driver.


An example (without my changes): 

```ruby
~/oss/test_cql_driver bundle
Resolving dependencies...
Using ione 1.2.1
Using cassandra-driver 2.1.4
Using bundler 1.10.5
Bundle complete! 1 Gemfile dependency, 3 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
~/oss/test_cql_driver be irb
irb(main):001:0> require 'cassandra'
=> true
irb(main):002:0> session = Cassandra.cluster.connect('test_driver')
=> #<Cassandra::Session:0x3fff5ab026f8>
irb(main):003:0> session.execute("select * from foo where user_id = ?", arguments: [10])
Cassandra::Errors::InvalidError: Expected 4 or 0 byte int (8)
	from /Users/vijay/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/cassandra-driver-2.1.4/lib/cassandra/future.rb:570:in `get'
	from /Users/vijay/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/cassandra-driver-2.1.4/lib/cassandra/future.rb:363:in `get'
	from /Users/vijay/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/cassandra-driver-2.1.4/lib/cassandra/session.rb:118:in `execute'
	from (irb):3
	from /Users/vijay/.rbenv/versions/1.9.3-p484/bin/irb:12:in `<main>'
```

With my changes:
```ruby
~/oss/test_cql_driver bundle
Resolving dependencies...
Using ione 1.2.1
Using cassandra-driver 2.1.4 from source at ../ruby-driver
Using bundler 1.10.5
Bundle complete! 1 Gemfile dependency, 3 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
~/oss/test_cql_driver be irb
irb(main):001:0> require 'cassandra'
=> true
irb(main):002:0> session = Cassandra.cluster.connect('test_driver')
=> #<Cassandra::Session:0x3ff3bbaa8f18>
irb(main):003:0> session.execute("select * from foo where user_id = ?", arguments: [10], type_hints: [:int])
=> #<Cassandra::Result:0x3ff3b98c8ca4 @rows=[{"user_id"=>10, "name"=>"asdf"}] @last_page=true>
```

type_hints can also be a hash if arguments is for named parameters:

```ruby
~/oss/test_cql_driver be irb
irb(main):001:0> require 'cassandra'
=> true
irb(main):002:0> session = Cassandra.cluster.connect('test_driver')
=> #<Cassandra::Session:0x3fcf16308cc8>
irb(main):003:0> session.execute("insert into foo (user_id, name) values (?,?)", arguments: {user_id: 42, name: "a_name"})
Cassandra::Errors::InvalidError: Expected 4 or 0 byte int (8)
	from /Users/vijay/oss/ruby-driver/lib/cassandra/future.rb:570:in `get'
	from /Users/vijay/oss/ruby-driver/lib/cassandra/future.rb:363:in `get'
	from /Users/vijay/oss/ruby-driver/lib/cassandra/session.rb:121:in `execute'
	from (irb):3
	from /Users/vijay/.rbenv/versions/1.9.3-p484/bin/irb:12:in `<main>'
irb(main):004:0> session.execute("insert into foo (user_id, name) values (?,?)", arguments: {user_id: 42, name: "a_name"}, type_hints: {user_id: :int, name: :varchar})
=> #<Cassandra::Result:0x3fcf1547434c @rows=[] @last_page=true>
```

It also works with batches of simple statements.  Prepared statements don't need type hints since it gets the type information from cassandra itself. 