### PR TITLE
Added \ after RSA for script in ruby-driver/features/security readme …

### DIFF
--- a/features/security/README.md
+++ b/features/security/README.md
@@ -188,7 +188,7 @@ cnode_alias=driver
 cstore_pass="some very long and secure password"
 
 keytool -genkeypair -noprompt \
-  -keyalg RSA
+  -keyalg RSA \
   -validity 36500 \
   -alias "$cnode_alias" \
   -keystore "$cnode_alias.keystore" \


### PR DESCRIPTION
The script was not running without "\" after RSA. By adding "\", things worked fine. 