### PR TITLE
Make the udf/uda minitests run a little faster

### DIFF
--- a/integration/functions/schema_change_listener.rb
+++ b/integration/functions/schema_change_listener.rb
@@ -15,27 +15,48 @@ class SchemaChangeListener
     end
   end
 
-  def initialize
+  def initialize(cluster)
+    @cluster = cluster
     @conditions = {}
   end
 
-  def wait_for_change(keyspace, timeout = nil, &block)
+  def wait_for_change(keyspace_name, timeout = nil, &block)
     # First run the block and see if it succeeds; if so, there's nothing
     # to wait for.
-    result = block.call(keyspace)
+    result = block.call(@cluster.keyspace(keyspace_name))
     return result if result
 
     # Ok, looks like we do need to wait...
-    promise = Cassandra::Future.promise
-    @conditions[keyspace.name] ||= []
-    @conditions[keyspace.name] << Condition.new(promise, &block)
+    begin
+      promise = Cassandra::Future.promise
+      @conditions[keyspace_name] ||= []
+      @conditions[keyspace_name] << Condition.new(promise, &block)
 
-    promise.future.get(timeout)
-  ensure
-    @conditions[keyspace.name].reject! { |c| c.promise == promise }
+      promise.future.get(timeout)
+    ensure
+      # Clean up the fulfilled/broken promise (e.g. the Condition associated
+      # with the promise)
+      @conditions[keyspace_name].reject! { |c| c.promise == promise }
+    end
+  end
+
+
+  def wait_for_function(keyspace_name, function_name, *args)
+    wait_for_change(keyspace_name, 2) do |ks|
+      ks.has_function?(function_name, *args)
+    end
+  end
+
+  def wait_for_aggregate(keyspace_name, aggregate_name, *args)
+    wait_for_change(keyspace_name, 2) do |ks|
+      ks.has_aggregate?(aggregate_name, *args)
+    end
   end
 
   def keyspace_changed(keyspace)
+    # This looks a little strange, but here's the idea: if we don't have
+    # Condition's for this keyspace, immediately return. Otherwise, for each
+    # Condition, evaluate with the keyspace.
     @conditions.fetch(keyspace.name) { return }.each { |c| c.evaluate(keyspace) }
     nil
   end

--- a/integration/functions/schema_change_listener.rb
+++ b/integration/functions/schema_change_listener.rb
@@ -1,0 +1,38 @@
+class SchemaChangeListener
+  class Condition
+    def initialize(promise, &block)
+      @promise = promise
+      @block   = block
+    end
+
+    def evaluate(keyspace)
+      result = @block.call(keyspace)
+      @promise.fulfill(result) if result
+    rescue => e
+      @promise.break(e)
+    end
+  end
+
+  def initialize
+    @conditions = {}
+  end
+
+  def wait_for_change(keyspace, timeout = nil, &block)
+    # First run the block and see if it succeeds; if so, there's nothing
+    # to wait for.
+    result = block.call(keyspace)
+    return result if result
+
+    # Ok, looks like we do need to wait...
+    promise = Cassandra::Future.promise
+    @conditions[keyspace.name] ||= []
+    @conditions[keyspace.name] << Condition.new(promise, &block)
+
+    promise.future.get(timeout)
+  end
+
+  def keyspace_changed(keyspace)
+    @conditions.fetch(keyspace.name) { return }.each { |c| c.evaluate(keyspace) }
+    nil
+  end
+end

--- a/integration/functions/schema_change_listener.rb
+++ b/integration/functions/schema_change_listener.rb
@@ -1,5 +1,7 @@
 class SchemaChangeListener
   class Condition
+    attr_reader :promise
+
     def initialize(promise, &block)
       @promise = promise
       @block   = block
@@ -29,6 +31,8 @@ class SchemaChangeListener
     @conditions[keyspace.name] << Condition.new(promise, &block)
 
     promise.future.get(timeout)
+  ensure
+    @conditions[keyspace.name].reject! { |c| c.promise == promise }
   end
 
   def keyspace_changed(keyspace)

--- a/integration/functions/schema_change_listener.rb
+++ b/integration/functions/schema_change_listener.rb
@@ -18,6 +18,7 @@ class SchemaChangeListener
   def initialize(cluster)
     @cluster = cluster
     @conditions = {}
+    @cluster.register(self)
   end
 
   def wait_for_change(keyspace_name, timeout = nil, &block)

--- a/integration/functions/user_defined_aggregate_test.rb
+++ b/integration/functions/user_defined_aggregate_test.rb
@@ -74,7 +74,6 @@ class UserDefinedAggregateTest < IntegrationTestCase
           schema_refresh_timeout: 0.1
       )
       @listener = SchemaChangeListener.new(@cluster)
-      @cluster.register(@listener)
       @session = @cluster.connect('simplex')
     end
   end

--- a/integration/functions/user_defined_aggregate_test.rb
+++ b/integration/functions/user_defined_aggregate_test.rb
@@ -127,8 +127,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND 0"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("sum_agg", int)
 
     assert_equal "sum_agg", aggregate.name
@@ -147,8 +148,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND 0"
     )
 
-    sleep(4)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg", smallint)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg", smallint)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("sum_agg", smallint)
     assert cluster.keyspace("simplex").has_function?("sum_int", smallint, smallint)
     state_function = cluster.keyspace("simplex").function("sum_int", smallint, smallint)
@@ -190,16 +192,17 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND 0"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg_delete", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg_delete", int)
+    end
     assert cluster.keyspace("simplex").has_aggregate?("sum_agg_delete", smallint)
 
     session.execute("DROP AGGREGATE sum_agg_delete(smallint)")
 
-    sleep(2)
+    assert_wait_and_retry_until(2) do
+      !cluster.keyspace("simplex").has_aggregate?("sum_agg_delete", smallint)
+    end
     assert cluster.keyspace("simplex").has_aggregate?("sum_agg_delete", int)
-    assert !cluster.keyspace("simplex").has_aggregate?("sum_agg_delete", smallint)
-
   ensure
     cluster && cluster.close
   end
@@ -235,8 +238,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND {}"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("group_and_sum", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("group_and_sum", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("group_and_sum", int)
 
     assert_equal "group_and_sum", aggregate.name
@@ -255,8 +259,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND NULL"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("group_and_sum2", smallint)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("group_and_sum2", smallint)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("group_and_sum2", smallint)
     assert cluster.keyspace("simplex").has_function?("state_group_and_sum", map(int, smallint), smallint)
     state_function = cluster.keyspace("simplex").function("state_group_and_sum", map(int, smallint), smallint)
@@ -298,8 +303,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     STYPE int"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("sum_agg", int)
     assert_equal 'null', aggregate.initial_state
 
@@ -310,8 +316,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND -1"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg2", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg2", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("sum_agg2", int)
     assert_equal "-1", aggregate.initial_state
 
@@ -322,8 +329,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND ['1', '2']"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("extend_list_agg", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("extend_list_agg", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("extend_list_agg", int)
     assert_equal "['1', '2']", aggregate.initial_state
 
@@ -334,8 +342,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND {1: 2, 3: 4}"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("update_map_agg", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("update_map_agg", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("update_map_agg", int)
     assert_equal "{1: 2, 3: 4}", aggregate.initial_state
   ensure
@@ -370,8 +379,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND 0"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg", int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg", int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("sum_agg", int)
     assert_equal [int], aggregate.argument_types
 
@@ -381,8 +391,9 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND 0"
     )
 
-    sleep(2)
-    assert cluster.keyspace("simplex").has_aggregate?("sum_agg", int, int)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?("sum_agg", int, int)
+    end
     aggregate = cluster.keyspace("simplex").aggregate("sum_agg", int, int)
     assert_equal [int, int], aggregate.argument_types
 
@@ -421,10 +432,20 @@ class UserDefinedAggregateTest < IntegrationTestCase
                     INITCOND 0"
     )
 
-    sleep(2)
+    assert_wait_and_retry_until(2) do
+      cluster.keyspace("simplex").has_aggregate?('sum_agg', int)
+    end
     original_aggregates = cluster.keyspace("simplex").aggregates
 
     session.execute("ALTER KEYSPACE simplex WITH durable_writes = false")
+
+    # This is a little strange. We need to wait until the alter causes
+    # an event that will refresh our cluster object, but there's no visible
+    # effect of a change (since nothing is supposed to change). So just sleep
+    # and hope.
+
+    sleep(2)
+
     new_aggregates = cluster.keyspace("simplex").aggregates
     assert_equal original_aggregates, new_aggregates
 

--- a/integration/functions/user_defined_aggregate_test.rb
+++ b/integration/functions/user_defined_aggregate_test.rb
@@ -116,8 +116,10 @@ class UserDefinedAggregateTest < IntegrationTestCase
   def test_can_create_udas
     skip("UDAs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert_empty cluster.keyspace("simplex").aggregates
@@ -178,8 +180,10 @@ class UserDefinedAggregateTest < IntegrationTestCase
   def test_can_delete_udas
     skip("UDAs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert_empty cluster.keyspace("simplex").aggregates
@@ -229,8 +233,10 @@ class UserDefinedAggregateTest < IntegrationTestCase
   def test_udas_with_finalfunc
     skip("UDAs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     # Initcond, finalfunc
@@ -298,8 +304,10 @@ class UserDefinedAggregateTest < IntegrationTestCase
   def test_uda_initconds
     skip("UDAs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert cluster.keyspace("simplex").has_function?("sum_int", int, int)
@@ -376,8 +384,10 @@ class UserDefinedAggregateTest < IntegrationTestCase
   def test_can_create_uda_same_name_different_types
     skip("UDAs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert cluster.keyspace("simplex").has_function?("sum_int", int, int)
@@ -431,8 +441,10 @@ class UserDefinedAggregateTest < IntegrationTestCase
   def test_aggregates_follow_keyspace_alter
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert cluster.keyspace("simplex").has_function?("sum_int", int, int)

--- a/integration/functions/user_defined_function_test.rb
+++ b/integration/functions/user_defined_function_test.rb
@@ -19,12 +19,26 @@
 require File.dirname(__FILE__) + '/../integration_test_case.rb'
 require_relative 'schema_change_listener'
 
+# noinspection RubyInstanceMethodNamingConvention
 class UserDefinedFunctionTest < IntegrationTestCase
   include Cassandra::Types
 
   def setup
-    @@ccm_cluster.setup_schema("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
-    @listener = SchemaChangeListener.new
+    unless CCM.cassandra_version < '2.2.0'
+      # noinspection RubyClassVariableUsageInspection
+      @@ccm_cluster.setup_schema("CREATE KEYSPACE simplex WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+      @cluster = Cassandra.cluster(
+          schema_refresh_delay: 0.1,
+          schema_refresh_timeout: 0.1
+      )
+      @listener = SchemaChangeListener.new(@cluster)
+      @cluster.register(@listener)
+      @session = @cluster.connect('simplex')
+    end
+  end
+
+  def teardown
+    @cluster.close
   end
 
   # Test raising error for nonexistent UDF
@@ -41,18 +55,13 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_raise_error_on_nonexisting_udf
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster
-    session = cluster.connect("simplex")
-
-    session.execute("CREATE TABLE mytable (a int PRIMARY KEY, b text)")
+    @session.execute('CREATE TABLE mytable (a int PRIMARY KEY, b text)')
 
     assert_raises(Cassandra::Errors::InvalidError) do
-      session.execute("SELECT nonexisting(b) FROM mytable")
+      @session.execute('SELECT nonexisting(b) FROM mytable')
     end
-  ensure
-    cluster && cluster.close
   end
 
   # Test for creating a basic UDF
@@ -69,37 +78,27 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_can_create_udfs
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
+    assert_empty @cluster.keyspace('simplex').functions
 
-    assert_empty cluster.keyspace("simplex").functions
-
-    session.execute("CREATE FUNCTION sum_int(key int, val int)
+    @session.execute("CREATE FUNCTION sum_int(key int, val int)
                     RETURNS NULL ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("sum_int", int, int)
-    end
+    @listener.wait_for_function('simplex', 'sum_int', int, int)
 
-    function = cluster.keyspace("simplex").function("sum_int", int, int)
+    function = @cluster.keyspace('simplex').function('sum_int', int, int)
 
-    assert_equal "sum_int", function.name
-    assert_equal "javascript", function.language
+    assert_equal 'sum_int', function.name
+    assert_equal 'javascript', function.language
     assert_equal int, function.type
     refute function.called_on_null?
-    assert function.has_argument?("key")
-    assert function.has_argument?("val")
+    assert function.has_argument?('key')
+    assert function.has_argument?('val')
     function.each_argument { |arg| assert_equal int, arg.type }
-  ensure
-    cluster && cluster.close
   end
 
   # Test for deleting a basic UDF
@@ -115,43 +114,30 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_can_delete_udfs
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
+    assert_empty @cluster.keyspace('simplex').functions
 
-    assert_empty cluster.keyspace("simplex").functions
-
-    session.execute("CREATE FUNCTION sum_int_delete(key int, val int)
+    @session.execute("CREATE FUNCTION sum_int_delete(key int, val int)
                     RETURNS NULL ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
-    session.execute("CREATE FUNCTION sum_int_delete(key smallint, val smallint)
+    @session.execute("CREATE FUNCTION sum_int_delete(key smallint, val smallint)
                     RETURNS NULL ON NULL INPUT
                     RETURNS smallint
                     LANGUAGE javascript AS 'key + val'"
     )
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("sum_int_delete", int, int)
-    end
+    @listener.wait_for_function('simplex', 'sum_int_delete', int, int)
+    @listener.wait_for_function('simplex', 'sum_int_delete', smallint, smallint)
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("sum_int_delete", smallint, smallint)
-    end
+    @session.execute('DROP FUNCTION sum_int_delete(smallint, smallint)')
 
-    session.execute("DROP FUNCTION sum_int_delete(smallint, smallint)")
-
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      !ks.has_function?("sum_int_delete", smallint, smallint)
+    @listener.wait_for_change('simplex', 2) do |ks|
+      !ks.has_function?('sum_int_delete', smallint, smallint)
     end
-    assert cluster.keyspace("simplex").has_function?("sum_int_delete", int, int)
-  ensure
-    cluster && cluster.close
+    assert @cluster.keyspace('simplex').has_function?('sum_int_delete', int, int)
   end
 
   # Test that varchar and text argument types are treated the same.
@@ -170,47 +156,37 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_varchar_udf
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
+    assert_empty @cluster.keyspace('simplex').functions
 
-    assert_empty cluster.keyspace("simplex").functions
-
-    session.execute("CREATE FUNCTION varchar_or_text(key varchar)
+    @session.execute("CREATE FUNCTION varchar_or_text(key varchar)
                     RETURNS NULL ON NULL INPUT
                     RETURNS varchar
                     LANGUAGE java AS 'return key;'"
     )
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("varchar_or_text", text)
-    end
+    @listener.wait_for_function('simplex', 'varchar_or_text', text)
 
-    function = cluster.keyspace("simplex").function("varchar_or_text", text)
+    function = @cluster.keyspace('simplex').function('varchar_or_text', text)
 
-    assert_equal "varchar_or_text", function.name
-    assert_equal "java", function.language
+    assert_equal 'varchar_or_text', function.name
+    assert_equal 'java', function.language
     assert_equal text, function.type
     refute function.called_on_null?
-    assert function.has_argument?("key")
+    assert function.has_argument?('key')
     function.each_argument { |arg| assert_equal text, arg.type }
 
     # Do the same checks, with varchar...
-    assert cluster.keyspace("simplex").has_function?("varchar_or_text", varchar)
-    function = cluster.keyspace("simplex").function("varchar_or_text", varchar)
+    assert @cluster.keyspace('simplex').has_function?('varchar_or_text', varchar)
+    function = @cluster.keyspace('simplex').function('varchar_or_text', varchar)
 
-    assert_equal "varchar_or_text", function.name
-    assert_equal "java", function.language
+    assert_equal 'varchar_or_text', function.name
+    assert_equal 'java', function.language
     assert_equal varchar, function.type
     refute function.called_on_null?
-    assert function.has_argument?("key")
+    assert function.has_argument?('key')
     function.each_argument { |arg| assert_equal varchar, arg.type }
-  ensure
-    cluster && cluster.close
   end
 
   # Test for creating two UDFs with the same name, but different types
@@ -227,49 +203,36 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_can_create_udf_same_name_different_types
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
+    assert_empty @cluster.keyspace('simplex').functions
 
-    assert_empty cluster.keyspace("simplex").functions
-
-    session.execute("CREATE FUNCTION sum_int(key int, val int)
+    @session.execute("CREATE FUNCTION sum_int(key int, val int)
                     RETURNS NULL ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("sum_int", int, int)
-    end
+    @listener.wait_for_function('simplex', 'sum_int', int, int)
 
-    function = cluster.keyspace("simplex").function("sum_int", int, int)
+    function = @cluster.keyspace('simplex').function('sum_int', int, int)
     function.each_argument { |arg| assert_equal int, arg.type }
 
-    session.execute("CREATE FUNCTION sum_int(key smallint, val smallint)
+    @session.execute("CREATE FUNCTION sum_int(key smallint, val smallint)
                     RETURNS NULL ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("sum_int", smallint, smallint)
-    end
+    @listener.wait_for_function('simplex', 'sum_int', smallint, smallint)
 
-    function = cluster.keyspace("simplex").function("sum_int", smallint, smallint)
-    # keyspace#function retrieves the first UDF, so the first one is retrieved here
+    function = @cluster.keyspace('simplex').function('sum_int', smallint, smallint)
     function.each_argument { |arg| assert_equal smallint, arg.type }
 
     # Make sure the original function is there, too.
-    assert cluster.keyspace("simplex").has_function?("sum_int", int, int)
-    function = cluster.keyspace("simplex").function("sum_int", int, int)
+    assert @cluster.keyspace('simplex').has_function?('sum_int', int, int)
+    function = @cluster.keyspace('simplex').function('sum_int', int, int)
     function.each_argument { |arg| assert_equal int, arg.type }
-  ensure
-    cluster && cluster.close
   end
 
   # Test for creating a UDF with no arguments
@@ -284,28 +247,18 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_can_create_function_no_argument
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
-
-    session.execute("CREATE FUNCTION print_time()
+    @session.execute("CREATE FUNCTION print_time()
                     RETURNS NULL ON NULL INPUT
                     RETURNS bigint
                     LANGUAGE java AS 'return System.currentTimeMillis() / 1000L;'"
     )
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?("print_time")
-    end
+    @listener.wait_for_function('simplex', 'print_time')
 
-    function = cluster.keyspace("simplex").function("print_time")
+    function = @cluster.keyspace('simplex').function('print_time')
     assert_empty function.each_argument
-  ensure
-    cluster && cluster.close
   end
 
   # Test for maintaining metadata during keyspace changes
@@ -322,41 +275,31 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_functions_follow_keyspace_alter
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
-
-    session.execute("CREATE FUNCTION sum_int(key int, val int)
+    @session.execute("CREATE FUNCTION sum_int(key int, val int)
                     RETURNS NULL ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
 
+    @listener.wait_for_function('simplex', 'sum_int', int, int)
 
-    @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.has_function?('sum_int', int, int)
-    end
+    original_functions = @cluster.keyspace('simplex').functions
 
-    original_functions = cluster.keyspace("simplex").functions
-
-    session.execute("ALTER KEYSPACE simplex WITH durable_writes = false")
+    @session.execute('ALTER KEYSPACE simplex WITH durable_writes = false')
 
     # This is a little strange. We need to wait until the alter causes
-    # an event that will refresh our cluster object, but there's no visible
-    # effect of a change (since nothing is supposed to change). So just sleep
-    # and hope.
+    # an event that will refresh our cluster object, but there's no really
+    # visible change other than the keyspace-changed event. So wait for that
+    # but with no real condition.
 
-    sleep(2)
-    new_functions = cluster.keyspace("simplex").functions
+    @listener.wait_for_change(@cluster.keyspace('simplex'), 2) do
+      true
+    end
+
+    new_functions = @cluster.keyspace('simplex').functions
     assert_equal original_functions, new_functions
-
-    session.execute("ALTER KEYSPACE simplex WITH durable_writes = true")
-  ensure
-    cluster && cluster.close
   end
 
   # Test for UDF null inputs
@@ -373,39 +316,35 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_cql_for_called_on_null
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(
-        schema_refresh_delay: 0.1,
-        schema_refresh_timeout: 0.1,
-        listeners: [@listener])
-    session = cluster.connect("simplex")
-
-    session.execute("CREATE FUNCTION sum_int(key int, val int)
+    @session.execute("CREATE FUNCTION sum_int(key int, val int)
                     RETURNS NULL ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
 
-    function = @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.function("sum_int", int, int)
+    function = @listener.wait_for_change('simplex', 2) do |ks|
+      ks.function('sum_int', int, int)
     end
     refute function.called_on_null?
-    assert_match /RETURNS NULL ON NULL INPUT/, cluster.keyspace("simplex").function("sum_int", int, int).to_cql
+    assert_match /RETURNS NULL ON NULL INPUT/,
+                 @cluster.keyspace('simplex').
+                     function('sum_int', int, int).to_cql
 
-    session.execute("CREATE FUNCTION sum_smallint(key smallint, val smallint)
+    @session.execute("CREATE FUNCTION sum_smallint(key smallint, val smallint)
                     CALLED ON NULL INPUT
                     RETURNS int
                     LANGUAGE javascript AS 'key + val'"
     )
 
-    function = @listener.wait_for_change(cluster.keyspace('simplex'), 2) do |ks|
-      ks.function("sum_smallint", smallint, smallint)
+    function = @listener.wait_for_change('simplex', 2) do |ks|
+      ks.function('sum_smallint', smallint, smallint)
     end
     assert function.called_on_null?
-    assert_match /CALLED ON NULL INPUT/, cluster.keyspace("simplex").function("sum_smallint", smallint, smallint).to_cql
-  ensure
-    cluster && cluster.close
+    assert_match /CALLED ON NULL INPUT/,
+                 @cluster.keyspace('simplex').
+                     function('sum_smallint', smallint, smallint).to_cql
   end
 
   # Test for invalid UDFs
@@ -422,20 +361,15 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_raise_error_on_invalid_udf
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
-
-    cluster = Cassandra.cluster
-    session = cluster.connect("simplex")
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
     assert_raises(Cassandra::Errors::InvalidError) do
-      session.execute("CREATE FUNCTION IF NOT EXISTS sum_int (key int, val int)
+      @session.execute("CREATE FUNCTION IF NOT EXISTS sum_int (key int, val int)
                       RETURNS NULL ON NULL INPUT
                       RETURNS int
                       LANGUAGE javascript AS 'key ++ val';"
       )
     end
-  ensure
-    cluster && cluster.close
   end
 
   # Test for serialization and deserialization of UDFs
@@ -452,13 +386,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   # @test_category functions:udf
   #
   def test_udf_serialization_deserialization
-    skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
-
-    cluster = Cassandra.cluster
-    session = cluster.connect("simplex")
+    skip('UDFs are only available in C* after 2.2') if CCM.cassandra_version < '2.2.0'
 
     # Create the UDF
-    session.execute("CREATE FUNCTION volume(dimensions tuple<double, double, double>)
+    @session.execute("CREATE FUNCTION volume(dimensions tuple<double, double, double>)
                     RETURNS NULL ON NULL INPUT
                     RETURNS double
                     LANGUAGE java
@@ -466,19 +397,24 @@ class UserDefinedFunctionTest < IntegrationTestCase
     )
 
     # Create the table
-    session.execute("CREATE TABLE inventory (item_id uuid PRIMARY KEY, dimensions Tuple<double,double,double>)")
+    @session.execute('CREATE TABLE inventory (
+                          item_id uuid PRIMARY KEY,
+                          dimensions Tuple<double,double,double>
+                      )'
+    )
 
     # Insert data
-    insert = session.prepare("INSERT INTO inventory (item_id, dimensions) VALUES (?, ?)")
-    session.execute(insert, arguments: [Cassandra::Uuid.new('0979dea5-5a65-446d-bad6-27d04d5dd8a5'),
+    insert = @session.prepare('INSERT INTO inventory (item_id, dimensions) VALUES (?, ?)')
+    @session.execute(insert, arguments: [Cassandra::Uuid.new('0979dea5-5a65-446d-bad6-27d04d5dd8a5'),
                                         Cassandra::Tuple.new(2.96, 0.450, 0.100)]
     )
 
     # Verify UDF
-    results = session.execute("SELECT item_id, volume(dimensions) FROM inventory WHERE item_id=0979dea5-5a65-446d-bad6-27d04d5dd8a5")
-    assert_equal 0.1332, results.first["simplex.volume(dimensions)"]
-  ensure
-    cluster && cluster.close
+    results = @session.execute(
+        'SELECT item_id, volume(dimensions)
+        FROM inventory
+        WHERE item_id=0979dea5-5a65-446d-bad6-27d04d5dd8a5'
+    )
+    assert_equal 0.1332, results.first['simplex.volume(dimensions)']
   end
-
 end

--- a/integration/functions/user_defined_function_test.rb
+++ b/integration/functions/user_defined_function_test.rb
@@ -71,8 +71,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_can_create_udfs
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert_empty cluster.keyspace("simplex").functions
@@ -115,8 +117,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_can_delete_udfs
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert_empty cluster.keyspace("simplex").functions
@@ -168,8 +172,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_varchar_udf
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert_empty cluster.keyspace("simplex").functions
@@ -223,8 +229,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_can_create_udf_same_name_different_types
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     assert_empty cluster.keyspace("simplex").functions
@@ -278,8 +286,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_can_create_function_no_argument
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     session.execute("CREATE FUNCTION print_time()
@@ -314,8 +324,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_functions_follow_keyspace_alter
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     session.execute("CREATE FUNCTION sum_int(key int, val int)
@@ -363,8 +375,10 @@ class UserDefinedFunctionTest < IntegrationTestCase
   def test_cql_for_called_on_null
     skip("UDFs are only available in C* after 2.2") if CCM.cassandra_version < '2.2.0'
 
-    cluster = Cassandra.cluster(schema_refresh_delay: 0.1, schema_refresh_timeout: 0.1)
-    cluster.register(@listener)
+    cluster = Cassandra.cluster(
+        schema_refresh_delay: 0.1,
+        schema_refresh_timeout: 0.1,
+        listeners: [@listener])
     session = cluster.connect("simplex")
 
     session.execute("CREATE FUNCTION sum_int(key int, val int)

--- a/integration/functions/user_defined_function_test.rb
+++ b/integration/functions/user_defined_function_test.rb
@@ -32,7 +32,6 @@ class UserDefinedFunctionTest < IntegrationTestCase
           schema_refresh_timeout: 0.1
       )
       @listener = SchemaChangeListener.new(@cluster)
-      @cluster.register(@listener)
       @session = @cluster.connect('simplex')
     end
   end

--- a/integration/integration_test_case.rb
+++ b/integration/integration_test_case.rb
@@ -32,25 +32,6 @@ class IntegrationTestCase < MiniTest::Unit::TestCase
 
   def self.after_suite
   end
-
-  # Wait and retry until the given block returns a truthy value or
-  # the timeout expires.
-  #
-  # @param timeout - timeout in seconds, may be fractional.
-  # @param block - block to execute repeatedly; careful about side effects.
-  # @return the result of the block.
-  def assert_wait_and_retry_until(timeout, msg = nil, &block)
-    expiration = Time.now + timeout
-    result = nil
-    while Time.now < expiration
-      result = block.call
-      break if result
-      sleep(0.25)
-    end
-
-    assert result, msg
-    result
-  end
 end
 
 class IntegrationUnit < MiniTest::Unit

--- a/integration/integration_test_case.rb
+++ b/integration/integration_test_case.rb
@@ -32,6 +32,25 @@ class IntegrationTestCase < MiniTest::Unit::TestCase
 
   def self.after_suite
   end
+
+  # Wait and retry until the given block returns a truthy value or
+  # the timeout expires.
+  #
+  # @param timeout - timeout in seconds, may be fractional.
+  # @param block - block to execute repeatedly; careful about side effects.
+  # @return the result of the block.
+  def assert_wait_and_retry_until(timeout, msg = nil, &block)
+    expiration = Time.now + timeout
+    result = nil
+    while Time.now < expiration
+      result = block.call
+      break if result
+      sleep(0.25)
+    end
+
+    assert result, msg
+    result
+  end
 end
 
 class IntegrationUnit < MiniTest::Unit


### PR DESCRIPTION
Replace static sleep 2's in UDF/UDA tests with calls to a new helper "assert_wait_and_retry_until" that tests the desired condition repeatedly until it succeeds or a timeout is hit.