### PR TITLE
Emit test name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :test do
   gem 'aruba'
   gem 'os'
   gem 'minitest', '< 5.0.0'
+  gem 'ansi'
   gem 'delorean'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ansi (1.5.0)
     aruba (0.9.0)
       childprocess (~> 0.5.6)
       contracts (~> 0.9)
@@ -83,6 +84,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ansi
   aruba
   bundler (~> 1.6)
   cassandra-driver!
@@ -103,4 +105,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/integration/integration_test_case.rb
+++ b/integration/integration_test_case.rb
@@ -22,6 +22,7 @@ require 'minitest/unit'
 require 'minitest/autorun'
 require 'cassandra'
 require 'delorean'
+require 'ansi/code'
 
 class IntegrationTestCase < MiniTest::Unit::TestCase
   @@ccm_cluster = nil
@@ -31,6 +32,10 @@ class IntegrationTestCase < MiniTest::Unit::TestCase
   end
 
   def self.after_suite
+  end
+
+  def before_setup
+    puts ANSI::Code.magenta("\n===== Begin #{self.__name__} ====")
   end
 end
 


### PR DESCRIPTION
At the start of each test case print out the test name. This should make it easier to track down where hangs occur.