### PR TITLE
Tweak Travis config to work in new Travis infrastructure:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.1.7
   - 2.2.3
   - jruby
-  - rbx-2.2.10
+  - rbx
 env:
   global:
     - FAIL_FAST=no
@@ -19,3 +19,13 @@ matrix:
 branches:
   only:
     - master
+before_install: |
+  gem cleanup bundler
+  if [[ k$TRAVIS_RUBY_VERSION = kjruby ]] ; then
+    gem uninstall -i /home/travis/.rvm/gems/jruby-src-1.7.19@global bundler -x
+  fi
+  if [[ k$TRAVIS_RUBY_VERSION = kjruby ]] || [[ k$TRAVIS_RUBY_VERSION = krbx* ]] ; then
+    gem install bundler -v 1.7.12
+  else
+    gem install bundler -v 1.11.2
+  fi


### PR DESCRIPTION
* For Rubinius, use rbx, not rbx-2.xx
* Add a before_install action that uninstalls whatever bundler(s) are installed on the VM and install the versions we need.