### PR TITLE
Fixed RUBY-156

### DIFF
--- a/lib/cassandra/protocol/cql_byte_buffer.rb
+++ b/lib/cassandra/protocol/cql_byte_buffer.rb
@@ -78,13 +78,15 @@ module Cassandra
       def read_double
         read(8).unpack(Formats::DOUBLE_FORMAT).first
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a double: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a double: #{e.message}", e.backtrace
       end
 
       def read_float
         read(4).unpack(Formats::FLOAT_FORMAT).first
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a float: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a float: #{e.message}", e.backtrace
       end
 
       def read_signed_int
@@ -92,13 +94,15 @@ module Cassandra
         return n if n <= 0x7fffffff
         n - 0xffffffff - 1
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode an int: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode an int: #{e.message}", e.backtrace
       end
       
       def read_unsigned_short
         read_short
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a short: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a short: #{e.message}", e.backtrace
       end
 
       def read_string
@@ -107,7 +111,8 @@ module Cassandra
         string.force_encoding(::Encoding::UTF_8)
         string
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a string: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a string: #{e.message}", e.backtrace
       end
 
       def read_long_string
@@ -116,13 +121,16 @@ module Cassandra
         string.force_encoding(::Encoding::UTF_8)
         string
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a long string: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a long string: #{e.message}",
+              e.backtrace
       end
 
       def read_uuid(impl=Uuid)
         impl.new(read_varint(16, false))
       rescue Errors::DecodingError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a UUID: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a UUID: #{e.message}", e.backtrace
       end
 
       def read_string_list
@@ -135,13 +143,16 @@ module Cassandra
         return nil if size & 0x80000000 == 0x80000000
         read(size)
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a bytes: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a bytes: #{e.message}", e.backtrace
       end
 
       def read_short_bytes
         read(read_unsigned_short)
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a short bytes: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a short bytes: #{e.message}",
+              e.backtrace
       end
 
       def read_option
@@ -159,12 +170,16 @@ module Cassandra
         port = read_int
         [ip_addr, port]
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode an INET: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode an INET: #{e.message}",
+              e.backtrace
       end
 
       def read_consistency
         index = read_unsigned_short
-        raise Errors::DecodingError, "Unknown consistency index #{index}" if index >= CONSISTENCIES.size || CONSISTENCIES[index].nil?
+        if index >= CONSISTENCIES.size || CONSISTENCIES[index].nil?
+          raise Errors::DecodingError, "Unknown consistency index #{index}"
+        end
         CONSISTENCIES[index]
       end
 
@@ -203,7 +218,8 @@ module Cassandra
         return n if n <= 0x7fff
         n - 0xffff - 1
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a smallint: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a smallint: #{e.message}", e.backtrace
       end
 
       def read_tinyint
@@ -211,7 +227,8 @@ module Cassandra
         return n if n <= 0x7f
         n - 0xff - 1
       rescue RangeError => e
-        raise Errors::DecodingError, "Not enough bytes available to decode a tinyint: #{e.message}", e.backtrace
+        raise Errors::DecodingError,
+              "Not enough bytes available to decode a tinyint: #{e.message}", e.backtrace
       end
 
       def append_tinyint(n)
@@ -277,7 +294,9 @@ module Cassandra
 
       def append_consistency(consistency)
         index = CONSISTENCIES.index(consistency)
-        raise Errors::EncodingError, %(Unknown consistency "#{consistency}") if index.nil? || CONSISTENCIES[index].nil?
+        if index.nil? || CONSISTENCIES[index].nil?
+          raise Errors::EncodingError, %(Unknown consistency "#{consistency}")
+        end
         append_short(index)
       end
 

--- a/lib/cassandra/protocol/v4.rb
+++ b/lib/cassandra/protocol/v4.rb
@@ -90,7 +90,9 @@ module Cassandra
             stream_id  = (frame_header >> 8) & 0xff
             stream_id  = (stream_id & 0x7f) - (stream_id & 0x80)
 
-            @handler.complete_request(stream_id, ErrorResponse.new(nil, nil, 0x000A, "Invalid or unsupported protocol version"))
+            error_response = ErrorResponse.new(nil, nil, 0x000A,
+                                               'Invalid or unsupported protocol version')
+            @handler.complete_request(stream_id, error_response)
 
             return
           end
@@ -159,7 +161,7 @@ module Cassandra
           nil
         end
 
-        def actual_decode(buffer, fields, size, code)
+        def actual_decode(buffer, fields, frame_length, code)
           protocol_version = (fields >> 24) & 0x7f
           compression      = ((fields >> 16) & 0x01) == 0x01
           tracing          = ((fields >> 16) & 0x02) == 0x02
@@ -169,41 +171,58 @@ module Cassandra
           stream_id        = (stream_id & 0x7fff) - (stream_id & 0x8000)
           opcode           = code & 0xff
 
+          # If we're dealing with a compressed body, read the whole body, decompress,
+          # and treat the uncompressed body as if that's what we got in the first place.
+          # This means, reset frame_length to that uncompressed size.
           if compression
             if @compressor
-              buffer = CqlByteBuffer.new(@compressor.decompress(buffer.read(size)))
-              size   = buffer.size
+              buffer = CqlByteBuffer.new(
+                  @compressor.decompress(buffer.read(frame_length)))
+              frame_length   = buffer.size
             else
-              raise Errors::DecodingError, 'Compressed frame received, but no compressor configured'
+              raise Errors::DecodingError,
+                    'Compressed frame received, but no compressor configured'
             end
           end
 
+          # We want to read one full frame; but after we read/parse chunks of the body
+          # there may be more cruft left in the frame that we don't care about. So,
+          # we save off the current size of the buffer, do all our reads for the
+          # frame, get the final remaining size, and based on that discard possible
+          # remaining bytes in the frame. In particular, we account for the possibility
+          # that the buffer contains some/all of a subsequent frame as well, and we
+          # don't want to mess with that.
+
+          buffer_starting_length = buffer.length
+
           if tracing
             trace_id = buffer.read_uuid
-            size     = buffer.size
           else
             trace_id = nil
           end
 
           if payload
             custom_payload = buffer.read_bytes_map.freeze
-            size           = buffer.size
           else
             custom_payload = nil
           end
 
           if warning
             warnings = buffer.read_string_list
-            size     = buffer.size
           else
             warnings = nil
           end
 
-          extra_length = buffer.length - size
-          response = decode_response(opcode, protocol_version, buffer, size, trace_id, custom_payload, warnings)
+          remaining_frame_length = frame_length -
+              (buffer_starting_length - buffer.length)
+          response = decode_response(opcode, protocol_version, buffer,
+                                     remaining_frame_length, trace_id, custom_payload,
+                                     warnings)
 
-          if buffer.length > extra_length
-            buffer.discard(buffer.length - extra_length)
+          # Calculate and discard remaining cruft in the frame.
+          extra_length = frame_length - (buffer_starting_length - buffer.length)
+          if extra_length > 0
+            buffer.discard(extra_length)
           end
 
           if stream_id == -1
@@ -213,119 +232,161 @@ module Cassandra
           end
         end
 
-        def decode_response(opcode, protocol_version, buffer, size, trace_id, custom_payload, warnings)
+        def decode_response(opcode, protocol_version, buffer, size, trace_id,
+                            custom_payload, warnings)
           case opcode
-          when 0x00 # ERROR
-            code    = buffer.read_int
-            message = buffer.read_string
+            when 0x00 # ERROR
+              code = buffer.read_int
+              message = buffer.read_string
 
-            case code
-            when 0x1000 then UnavailableErrorResponse.new(custom_payload, warnings, code, message, buffer.read_consistency, buffer.read_int, buffer.read_int)
-            when 0x1100 then WriteTimeoutErrorResponse.new(custom_payload, warnings, code, message, buffer.read_consistency, buffer.read_int, buffer.read_int, buffer.read_string)
-            when 0x1200 then ReadTimeoutErrorResponse.new(custom_payload, warnings, code, message, buffer.read_consistency, buffer.read_int, buffer.read_int, (buffer.read_byte != 0))
-            when 0x1300 then ReadFailureErrorResponse.new(custom_payload, warnings, code, message, buffer.read_consistency, buffer.read_int, buffer.read_int, buffer.read_int, (buffer.read_byte != 0))
-            when 0x1400 then FunctionFailureErrorResponse.new(custom_payload, warnings, code, message, buffer.read_string, buffer.read_string, buffer.read_string_list)
-            when 0x1500 then WriteFailureErrorResponse.new(custom_payload, warnings, code, message, buffer.read_consistency, buffer.read_int, buffer.read_int, buffer.read_int, buffer.read_string)
-            when 0x2400 then AlreadyExistsErrorResponse.new(custom_payload, warnings, code, message, buffer.read_string, buffer.read_string)
-            when 0x2500 then UnpreparedErrorResponse.new(custom_payload, warnings, code, message, buffer.read_short_bytes)
-            else
-              ErrorResponse.new(custom_payload, warnings, code, message)
-            end
-          when 0x02 # READY
-            READY
-          when 0x03 # AUTHENTICATE
-            AuthenticateResponse.new(buffer.read_string)
-          when 0x06 # SUPPORTED
-            SupportedResponse.new(buffer.read_string_multimap)
-          when 0x08 # RESULT
-            result_type = buffer.read_int
-            case result_type
-            when 0x0001 # Void
-              VoidResultResponse.new(custom_payload, warnings, trace_id)
-            when 0x0002 # Rows
-              original_buffer_length = buffer.length
-              column_specs, paging_state = Coder.read_metadata_v4(buffer)
-
-              if column_specs.nil?
-                consumed_bytes  = original_buffer_length - buffer.length
-                remaining_bytes = CqlByteBuffer.new(buffer.read(size - consumed_bytes - 4))
-                RawRowsResultResponse.new(custom_payload, warnings, protocol_version, remaining_bytes, paging_state, trace_id)
-              else
-                RowsResultResponse.new(custom_payload, warnings, Coder.read_values_v4(buffer, column_specs), column_specs, paging_state, trace_id)
+              case code
+                when 0x1000
+                  UnavailableErrorResponse.new(custom_payload, warnings, code, message,
+                                               buffer.read_consistency, buffer.read_int,
+                                               buffer.read_int)
+                when 0x1100
+                  WriteTimeoutErrorResponse.new(custom_payload, warnings, code, message,
+                                                buffer.read_consistency, buffer.read_int,
+                                                buffer.read_int, buffer.read_string)
+                when 0x1200
+                  ReadTimeoutErrorResponse.new(custom_payload, warnings, code, message,
+                                               buffer.read_consistency, buffer.read_int,
+                                               buffer.read_int, (buffer.read_byte != 0))
+                when 0x1300
+                  ReadFailureErrorResponse.new(custom_payload, warnings, code, message,
+                                               buffer.read_consistency, buffer.read_int,
+                                               buffer.read_int, buffer.read_int,
+                                               (buffer.read_byte != 0))
+                when 0x1400
+                  FunctionFailureErrorResponse.new(custom_payload, warnings, code,
+                                                   message, buffer.read_string,
+                                                   buffer.read_string,
+                                                   buffer.read_string_list)
+                when 0x1500
+                  WriteFailureErrorResponse.new(custom_payload, warnings, code, message,
+                                                buffer.read_consistency, buffer.read_int,
+                                                buffer.read_int, buffer.read_int,
+                                                buffer.read_string)
+                when 0x2400
+                  AlreadyExistsErrorResponse.new(custom_payload, warnings, code, message,
+                                                 buffer.read_string, buffer.read_string)
+                when 0x2500
+                  UnpreparedErrorResponse.new(custom_payload, warnings, code, message,
+                                              buffer.read_short_bytes)
+                else
+                  ErrorResponse.new(custom_payload, warnings, code, message)
               end
-            when 0x0003 # SetKeyspace
-              SetKeyspaceResultResponse.new(custom_payload, warnings, buffer.read_string, trace_id)
-            when 0x0004 # Prepared
-              id = buffer.read_short_bytes
-              pk_idx, params_metadata = Coder.read_prepared_metadata_v4(buffer)
-              result_metadata = Coder.read_metadata_v4(buffer).first
+            when 0x02 # READY
+              READY
+            when 0x03 # AUTHENTICATE
+              AuthenticateResponse.new(buffer.read_string)
+            when 0x06 # SUPPORTED
+              SupportedResponse.new(buffer.read_string_multimap)
+            when 0x08 # RESULT
+              result_type = buffer.read_int
+              case result_type
+                when 0x0001 # Void
+                  VoidResultResponse.new(custom_payload, warnings, trace_id)
+                when 0x0002 # Rows
+                  original_buffer_length = buffer.length
+                  column_specs, paging_state = Coder.read_metadata_v4(buffer)
 
-              PreparedResultResponse.new(custom_payload, warnings, id, params_metadata, result_metadata, pk_idx, trace_id)
-            when 0x0005 # SchemaChange
-              change    = buffer.read_string
-              target    = buffer.read_string
-              keyspace  = nil
-              name      = nil
-              arguments = EMPTY_LIST
+                  if column_specs.nil?
+                    consumed_bytes = original_buffer_length - buffer.length
+                    remaining_bytes =
+                        CqlByteBuffer.new(buffer.read(size - consumed_bytes - 4))
+                    RawRowsResultResponse.new(custom_payload, warnings, protocol_version,
+                                              remaining_bytes, paging_state, trace_id)
+                  else
+                    RowsResultResponse.new(custom_payload, warnings,
+                                           Coder.read_values_v4(buffer, column_specs),
+                                           column_specs, paging_state, trace_id)
+                  end
+                when 0x0003 # SetKeyspace
+                  SetKeyspaceResultResponse.new(custom_payload, warnings,
+                                                buffer.read_string, trace_id)
+                when 0x0004 # Prepared
+                  id = buffer.read_short_bytes
+                  pk_idx, params_metadata = Coder.read_prepared_metadata_v4(buffer)
+                  result_metadata = Coder.read_metadata_v4(buffer).first
 
-              case target
-              when Protocol::Constants::SCHEMA_CHANGE_TARGET_KEYSPACE
-                keyspace = buffer.read_string
-              when Protocol::Constants::SCHEMA_CHANGE_TARGET_TABLE,
-                   Protocol::Constants::SCHEMA_CHANGE_TARGET_UDT
-                keyspace = buffer.read_string
-                name     = buffer.read_string
-              when Protocol::Constants::SCHEMA_CHANGE_TARGET_FUNCTION,
-                   Protocol::Constants::SCHEMA_CHANGE_TARGET_AGGREGATE
-                keyspace  = buffer.read_string
-                name      = buffer.read_string
-                arguments = buffer.read_string_list
+                  PreparedResultResponse.new(custom_payload, warnings, id,
+                                             params_metadata, result_metadata, pk_idx,
+                                             trace_id)
+                when 0x0005 # SchemaChange
+                  change = buffer.read_string
+                  target = buffer.read_string
+                  name = nil
+                  arguments = EMPTY_LIST
+
+                  case target
+                    when Protocol::Constants::SCHEMA_CHANGE_TARGET_KEYSPACE
+                      keyspace = buffer.read_string
+                    when Protocol::Constants::SCHEMA_CHANGE_TARGET_TABLE,
+                        Protocol::Constants::SCHEMA_CHANGE_TARGET_UDT
+                      keyspace = buffer.read_string
+                      name = buffer.read_string
+                    when Protocol::Constants::SCHEMA_CHANGE_TARGET_FUNCTION,
+                        Protocol::Constants::SCHEMA_CHANGE_TARGET_AGGREGATE
+                      keyspace = buffer.read_string
+                      name = buffer.read_string
+                      arguments = buffer.read_string_list
+                    else
+                      raise Errors::DecodingError,
+                            "Unsupported event target: #{target.inspect}"
+                  end
+
+                  SchemaChangeResultResponse.new(custom_payload, warnings, change,
+                                                 keyspace, name, target, arguments,
+                                                 trace_id)
+                else
+                  raise Errors::DecodingError,
+                        "Unsupported result type: #{result_type.inspect}"
               end
+            when 0x0C # EVENT
+              event_type = buffer.read_string
+              case event_type
+                when 'SCHEMA_CHANGE'
+                  change = buffer.read_string
+                  target = buffer.read_string
+                  arguments = EMPTY_LIST
 
-              SchemaChangeResultResponse.new(custom_payload, warnings, change, keyspace, name, target, arguments, trace_id)
-            else
-              raise Errors::DecodingError, "Unsupported result type: #{result_type.inspect}"
-            end
-          when 0x0C # EVENT
-            event_type = buffer.read_string
-            case event_type
-            when 'SCHEMA_CHANGE'
-              change    = buffer.read_string
-              target    = buffer.read_string
-              keyspace  = nil
-              arguments = EMPTY_LIST
+                  case target
+                    when Protocol::Constants::SCHEMA_CHANGE_TARGET_KEYSPACE
+                      keyspace = buffer.read_string
+                      name = nil
+                    when Protocol::Constants::SCHEMA_CHANGE_TARGET_TABLE,
+                        Protocol::Constants::SCHEMA_CHANGE_TARGET_UDT,
+                        Protocol::Constants::SCHEMA_CHANGE_TARGET_FUNCTION,
+                        Protocol::Constants::SCHEMA_CHANGE_TARGET_AGGREGATE
+                      keyspace = buffer.read_string
+                      name = buffer.read_string
+                    else
+                      raise Errors::DecodingError,
+                            "Unsupported event target: #{target.inspect}"
+                  end
 
-              case target
-              when Protocol::Constants::SCHEMA_CHANGE_TARGET_KEYSPACE
-                keyspace = buffer.read_string
-                name     = nil
-              when Protocol::Constants::SCHEMA_CHANGE_TARGET_TABLE,
-                   Protocol::Constants::SCHEMA_CHANGE_TARGET_UDT,
-                   Protocol::Constants::SCHEMA_CHANGE_TARGET_FUNCTION,
-                   Protocol::Constants::SCHEMA_CHANGE_TARGET_AGGREGATE
-                keyspace = buffer.read_string
-                name     = buffer.read_string
-              end
-
-              if target == Protocol::Constants::SCHEMA_CHANGE_TARGET_FUNCTION \
+                  if target == Protocol::Constants::SCHEMA_CHANGE_TARGET_FUNCTION \
               || target == Protocol::Constants::SCHEMA_CHANGE_TARGET_AGGREGATE
-                arguments = buffer.read_string_list
-              end
+                    arguments = buffer.read_string_list
+                  end
 
-              SchemaChangeEventResponse.new(change, keyspace, name, target, arguments)
-            when 'STATUS_CHANGE'
-              StatusChangeEventResponse.new(buffer.read_string, *buffer.read_inet)
-            when 'TOPOLOGY_CHANGE'
-              TopologyChangeEventResponse.new(buffer.read_string, *buffer.read_inet)
+                  SchemaChangeEventResponse.new(change, keyspace, name, target, arguments)
+                when 'STATUS_CHANGE'
+                  StatusChangeEventResponse.new(buffer.read_string, *buffer.read_inet)
+                when 'TOPOLOGY_CHANGE'
+                  TopologyChangeEventResponse.new(buffer.read_string, *buffer.read_inet)
+                else
+                  raise Errors::DecodingError,
+                        "Unsupported event type: #{event_type.inspect}"
+              end
+            when 0x0E # AUTH_CHALLENGE
+              AuthChallengeResponse.new(buffer.read_bytes)
+            when 0x10 # AUTH_SUCCESS
+              AuthSuccessResponse.new(buffer.read_bytes)
             else
-              raise Errors::DecodingError, "Unsupported event type: #{event_type.inspect}"
-            end
-          when 0x0E # AUTH_CHALLENGE
-            AuthChallengeResponse.new(buffer.read_bytes)
-          when 0x10 # AUTH_SUCCESS
-            AuthSuccessResponse.new(buffer.read_bytes)
-          else
-            raise Errors::DecodingError, "Unsupported response opcode: #{opcode.inspect}"
+              raise Errors::DecodingError,
+                    "Unsupported response opcode: #{opcode.inspect}"
           end
         end
       end

--- a/spec/cassandra/protocol/v3/decoder_spec.rb
+++ b/spec/cassandra/protocol/v3/decoder_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 
 module Cassandra
   module Protocol
-    module V4
+    module V3
       describe(Decoder) do
         let(:handler) { double('handler') }
         let(:subject) { Decoder.new(handler) }
@@ -43,20 +43,82 @@ module Cassandra
                 expect(id).to eq(0)
                 expect(response.metadata).to eq([
                   ['simplex', 'users', 'id', Types.int],
-                  ['simplex', 'users', 'location', Types.list(Types.udt('simplex', 'address',
-                                                                        'street', Types.text,
-                                                                        'zipcode', Types.int,
-                                                                        'city', Types.text))]
+                  ['simplex', 'users', 'location', Types.list(
+                      Types.udt('simplex', 'address',
+                                'street', Types.text,
+                                'zipcode', Types.int,
+                                'city', Types.text))]
                 ])
                 expect(response.rows.first).to eq({
                   'id' => 0,
                   'location' => [
-                    Cassandra::UDT.new('street', '123 Main St.', 'zipcode', 78723, 'city', nil),
-                    Cassandra::UDT.new('street', '4567 Main St.', 'zipcode', 87654, 'city', nil)
+                    Cassandra::UDT.new('street', '123 Main St.', 'zipcode', 78723,
+                                       'city', nil),
+                    Cassandra::UDT.new('street', '4567 Main St.', 'zipcode', 87654,
+                                       'city', nil)
                   ]
                 })
               end
               subject << data
+            end
+          end
+
+          context('with compressed body') do
+            let(:subject) {
+              Decoder.new(handler, Cassandra::Compression::Compressors::Snappy.new)
+            }
+
+            it 'should decode properly' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.rows.count).to eq(2)
+              end
+              subject << "\x83\x01\x00\x00\b\x00\x00\x00<K\x1C\x00\x00\x00\x02\x00\x00\x00\x01\x05\bd\asimplex\x00\x04base\x00\x02f1\x00\t\x00\x02f2\x00\t\x05\x1F\b\x00\x00\x04\r+.\b\x00 \x02\x00\x00\x00\x04\x00\x00\x00\x02"
+            end
+
+            it 'should handle extra cruft in compressed body' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.rows.count).to eq(2)
+              end
+              subject << "\x83\x01\x00\x00\b\x00\x00\x00@O\x1C\x00\x00\x00\x02\x00\x00\x00\x01\x05\bd\asimplex\x00\x04base\x00\x02f1\x00\t\x00\x02f2\x00\t\x05\x1F\b\x00\x00\x04\r+.\b\x000\x02\x00\x00\x00\x04\x00\x00\x00\x02JUNK"
+            end
+          end
+
+          context('with multiple frames') do
+            it 'should handle frames containing trace data' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.trace_id).
+                    to eq(Uuid.new("d5399070-c142-11e5-a48b-09d3de2f1e32"))
+              end
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(1)
+                expect(response.trace_id).
+                    to eq(Uuid.new("d539de92-c142-11e5-a48b-09d3de2f1e32"))
+              end
+
+              subject << "\x83\x02\x00\x00\b\x00\x00\x00\x14\xD59\x90p\xC1B\x11\xE5\xA4\x8B\t\xD3\xDE/\x1E2\x00\x00\x00\x01" \
+                         "\x83\x02\x00\x01\b\x00\x00\x00\x14\xD59\xDE\x92\xC1B\x11\xE5\xA4\x8B\t\xD3\xDE/\x1E2\x00\x00\x00\x01"
+            end
+
+            it 'should handle cruft in frames' do
+              # This is basically the same test as the trace test above, but the first
+              # frame has a few more characters in the body, which should be ignored.
+
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.trace_id).
+                    to eq(Uuid.new("d5399070-c142-11e5-a48b-09d3de2f1e32"))
+              end
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(1)
+                expect(response.trace_id).
+                    to eq(Uuid.new("d539de92-c142-11e5-a48b-09d3de2f1e32"))
+              end
+
+              subject << "\x83\x02\x00\x00\b\x00\x00\x00\x18\xD59\x90p\xC1B\x11\xE5\xA4\x8B\t\xD3\xDE/\x1E2\x00\x00\x00\x01JUNK" \
+                         "\x83\x02\x00\x01\b\x00\x00\x00\x14\xD59\xDE\x92\xC1B\x11\xE5\xA4\x8B\t\xD3\xDE/\x1E2\x00\x00\x00\x01"
             end
           end
         end

--- a/spec/cassandra/protocol/v4/decoder_spec.rb
+++ b/spec/cassandra/protocol/v4/decoder_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 
 module Cassandra
   module Protocol
-    module V3
+    module V4
       describe(Decoder) do
         let(:handler) { double('handler') }
         let(:subject) { Decoder.new(handler) }
@@ -43,20 +43,95 @@ module Cassandra
                 expect(id).to eq(0)
                 expect(response.metadata).to eq([
                   ['simplex', 'users', 'id', Types.int],
-                  ['simplex', 'users', 'location', Types.list(Types.udt('simplex', 'address',
-                                                                        'street', Types.text,
-                                                                        'zipcode', Types.int,
-                                                                        'city', Types.text))]
+                  ['simplex', 'users', 'location', Types.list(
+                      Types.udt('simplex', 'address',
+                                'street', Types.text,
+                                'zipcode', Types.int,
+                                'city', Types.text))]
                 ])
                 expect(response.rows.first).to eq({
                   'id' => 0,
                   'location' => [
-                    Cassandra::UDT.new('street', '123 Main St.', 'zipcode', 78723, 'city', nil),
-                    Cassandra::UDT.new('street', '4567 Main St.', 'zipcode', 87654, 'city', nil)
+                    Cassandra::UDT.new('street', '123 Main St.', 'zipcode', 78723,
+                                       'city', nil),
+                    Cassandra::UDT.new('street', '4567 Main St.', 'zipcode', 87654,
+                                       'city', nil)
                   ]
                 })
               end
               subject << data
+            end
+          end
+
+          context('with compressed body') do
+            let(:subject) {
+              Decoder.new(handler, Cassandra::Compression::Compressors::Snappy.new)
+            }
+
+            it 'should decode properly' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.rows.count).to eq(2)
+              end
+              subject << "\x84\x01\x00\x00\b\x00\x00\x00<K\x1C\x00\x00\x00\x02\x00\x00\x00\x01\x05\bd\asimplex\x00\x04base\x00\x02f1\x00\t\x00\x02f2\x00\t\x05\x1F\b\x00\x00\x04\r+.\b\x00 \x02\x00\x00\x00\x04\x00\x00\x00\x02"
+            end
+
+            it 'should handle extra cruft in compressed body' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.rows.count).to eq(2)
+              end
+              subject << "\x84\x01\x00\x00\b\x00\x00\x00@O\x1C\x00\x00\x00\x02\x00\x00\x00\x01\x05\bd\asimplex\x00\x04base\x00\x02f1\x00\t\x00\x02f2\x00\t\x05\x1F\b\x00\x00\x04\r+.\b\x000\x02\x00\x00\x00\x04\x00\x00\x00\x02JUNK"
+            end
+          end
+
+          context('with multiple frames') do
+            it 'should handle frames containing warnings' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.warnings).
+                    to eq(['Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.'])
+              end
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(1)
+                expect(response.warnings).
+                    to eq(['Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.'])
+              end
+              subject << "\x84\b\x00\x00\b\x00\x00\x00\xA8\x00\x01\x00\xA0Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.\x00\x00\x00\x01" \
+                         "\x84\b\x00\x01\b\x00\x00\x00\xA8\x00\x01\x00\xA0Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.\x00\x00\x00\x01"
+            end
+
+            it 'should handle frames containing trace data' do
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.trace_id).
+                    to eq(Uuid.new("d5399070-c142-11e5-a48b-09d3de2f1e32"))
+              end
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(1)
+                expect(response.trace_id).
+                    to eq(Uuid.new("d539de92-c142-11e5-a48b-09d3de2f1e32"))
+              end
+
+              subject << "\x84\x02\x00\x00\b\x00\x00\x00\x14\xD59\x90p\xC1B\x11\xE5\xA4\x8B\t\xD3\xDE/\x1E2\x00\x00\x00\x01" \
+                         "\x84\x02\x00\x01\b\x00\x00\x00\x14\xD59\xDE\x92\xC1B\x11\xE5\xA4\x8B\t\xD3\xDE/\x1E2\x00\x00\x00\x01"
+            end
+
+            it 'should handle cruft in frames' do
+              # This is basically the same test as the warnings test above, but the first
+              # frame has a few more characters in the body, which should be ignored.
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(0)
+                expect(response.warnings).
+                    to eq(['Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.'])
+              end
+              expect(handler).to receive(:complete_request) do |id, response|
+                expect(id).to eq(1)
+                expect(response.warnings).
+                    to eq(['Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.'])
+              end
+              subject << "\x84\b\x00\x00\b\x00\x00\x00\xAC\x00\x01\x00\xA0Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.\x00\x00\x00\x01JUNK" \
+                         "\x84\b\x00\x01\b\x00\x00\x00\xA8\x00\x01\x00\xA0Unlogged batch covering 2 partitions detected against table [simplex.base]. You should use a logged batch for atomicity, or asynchronous writes for performance.\x00\x00\x00\x01"
             end
           end
         end


### PR DESCRIPTION
Don't throw out the whole buffer when we see a warning in a frame, since the buffer may contain some/all of the next frame(s).