### PR TITLE
Correct the signature for Cassandra::Types#new_uuid

### DIFF
--- a/lib/cassandra/types.rb
+++ b/lib/cassandra/types.rb
@@ -193,7 +193,7 @@ module Cassandra
         Util.assert_instance_of(::Time, value, message, &block)
       end
 
-      def new_uuid(value, message, &block)
+      def new_uuid(value)
         Cassandra::Uuid.new(value)
       end
 


### PR DESCRIPTION
For some reason, Cassandra::Types#new_uuid has the same signature as the assert_#{@kind} methods, rather than the signature for new_#{@kind}.  This causes an error, since no 'message' argument gets passed via Cassandra::Types#new.