### PR TITLE
Correct the signature for Cassandra::Types#new_uuid

### DIFF
--- a/lib/cassandra/types.rb
+++ b/lib/cassandra/types.rb
@@ -193,7 +193,7 @@ module Cassandra
         Util.assert_instance_of(::Time, value, message, &block)
       end
 
-      def new_uuid(value, message, &block)
+      def new_uuid(value)
         Cassandra::Uuid.new(value)
       end
 


### PR DESCRIPTION
Redoing request https://github.com/datastax/ruby-driver/pull/123 now that CLA is signed.

This fixes the signature for Cassandra::Types#new_uuid to match the other new_#{@kind} methods, rather than the assert_#{@kind} methods