### PR TITLE
Fixed RUBY-155

### DIFF
--- a/spec/support/fake_io_reactor.rb
+++ b/spec/support/fake_io_reactor.rb
@@ -127,6 +127,10 @@ class FakeIoReactor
     self
   end
 
+  def timer_count
+    @timers.size
+  end
+
   def execute
     Ione::Future.resolved(yield)
   rescue => e


### PR DESCRIPTION
Request timeout should start counting when request is sent; in particular the timer for queued requests shouldn't start until it is sent to the io reactor.