### PR TITLE
Updating CI runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,25 @@ language: ruby
 script: bundle exec rake rspec
 bundler_args: --without development docs
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
-  - jruby
-  - rbx
+  - 2.2.4
+  - 2.3.0
+  - jruby-1.7.24
+  - jruby-9.0.5.0
 env:
   global:
     - FAIL_FAST=no
     - COVERAGE=no
 matrix:
-  allow_failures:
-    - rvm: rbx
   fast_finish: true
 branches:
   only:
     - master
 before_install: |
   gem cleanup bundler
-  if [[ k$TRAVIS_RUBY_VERSION = kjruby ]] ; then
-    gem uninstall -i /home/travis/.rvm/gems/jruby-src-1.7.19@global bundler -x
-  fi
-  if [[ k$TRAVIS_RUBY_VERSION = kjruby ]] || [[ k$TRAVIS_RUBY_VERSION = krbx* ]] ; then
+
+  if [[ k$TRAVIS_RUBY_VERSION = kjruby* ]] ; then
+    gem uninstall -i /home/travis/.rvm/gems/jruby-1.7.24@global bundler -x
+    gem uninstall -i /home/travis/.rvm/gems/jruby-9.0.5.0@global bundler -x
     gem install bundler -v 1.7.12
   else
     gem install bundler -v 1.11.2

--- a/build.yaml
+++ b/build.yaml
@@ -1,17 +1,13 @@
 ruby:
-  - 1.9.3
-  - 2.0
-  - 2.1
   - 2.2
   - 2.3
-  - jruby
-  - rbx-2.2
+  - jruby1.7
 cassandra:
   - 2.0
   - 2.1
   - 2.2
   - 3.0
-  - 3.1
+  - 3.3
 os:
   - ubuntu/trusty64
 build:


### PR DESCRIPTION
Rubies: 
- Dropped: MRI 1.9, 2.0, 2.1, and rbx. 
- Added: Jruby 9k

Cassandra:
- Dropped: 3.1
- Added: 3.3