### PR TITLE
Fixed RUBY-161

### DIFF
--- a/lib/cassandra/protocol/cql_protocol_handler.rb
+++ b/lib/cassandra/protocol/cql_protocol_handler.rb
@@ -32,7 +32,13 @@ module Cassandra
     #   puts "These options are supported: #{response.options}"
     class CqlProtocolHandler
       # @return [String] the current keyspace for the underlying connection
-      attr_reader :keyspace, :error
+      attr_reader :keyspace
+
+      # @return [Exception] outstanding error, from a failed connection.
+      attr_reader :error
+
+      # @return [Integer] the version of the protocol to use in communicating with C*.
+      attr_reader :protocol_version
 
       def initialize(connection,
                      scheduler,
@@ -41,6 +47,7 @@ module Cassandra
                      heartbeat_interval = 30,
                      idle_timeout = 60,
                      requests_per_connection = 128)
+        @protocol_version = protocol_version
         @connection = connection
         @scheduler = scheduler
         @compressor = compressor

--- a/spec/cassandra/cluster/client_spec.rb
+++ b/spec/cassandra/cluster/client_spec.rb
@@ -42,6 +42,10 @@ module Cassandra
       let(:driver) { Driver.new(driver_settings) }
       let(:client) { Client.new(driver.logger, driver.cluster_registry, driver.cluster_schema, driver.io_reactor, driver.connector, driver.load_balancing_policy, driver.reconnection_policy, driver.retry_policy, driver.address_resolution_policy, driver.connection_options, driver.futures_factory) }
 
+      before do
+        io_reactor.connection_options = driver.connection_options
+      end
+
       describe('defaults') do
         context 'for driver' do
           it 'should use local_one consistency' do

--- a/spec/cassandra/cluster/control_connection_spec.rb
+++ b/spec/cassandra/cluster/control_connection_spec.rb
@@ -142,7 +142,7 @@ module Cassandra
         cluster_registry.add_listener(driver.load_balancing_policy)
         cluster_registry.add_listener(control_connection)
         cluster_registry.host_found('127.0.0.1')
-
+        io_reactor.connection_options = connection_options
         io_reactor.on_connection do |connection|
           connection[:spec_rack]            = racks[connection.host]
           connection[:spec_data_center]     = data_centers[connection.host]
@@ -221,7 +221,7 @@ module Cassandra
 
           control_connection.connect_async.value
 
-          connection_options.protocol_version.should == 4
+          expect(connection_options.protocol_version).to eq(4)
         end
 
         it 'logs when it tries the next protocol version' do
@@ -236,7 +236,6 @@ module Cassandra
               Protocol::SupportedResponse.new('CQL_VERSION' => %w[3.0.0], 'COMPRESSION' => %w[lz4 snappy])
             end
           end
-
 
           control_connection.connect_async.value
           expect(logger).to have_received(:info).with("Host 127.0.0.1 doesn't support protocol version 7, downgrading")

--- a/spec/cassandra/cluster_spec.rb
+++ b/spec/cassandra/cluster_spec.rb
@@ -35,6 +35,10 @@ module Cassandra
 
     let(:cluster) { Cluster.new(driver.logger, io_reactor, executor, control_connection, cluster_registry, driver.cluster_schema, driver.cluster_metadata, driver.execution_options, driver.connection_options, load_balancing_policy, driver.reconnection_policy, driver.retry_policy, driver.address_resolution_policy, driver.connector, driver.futures_factory) }
 
+    before do
+      io_reactor.connection_options = driver.connection_options
+    end
+
     describe('#hosts') do
       it 'uses State#hosts' do
         expect(cluster.hosts).to eq(cluster_registry.hosts)

--- a/spec/support/stub_io_reactor.rb
+++ b/spec/support/stub_io_reactor.rb
@@ -377,6 +377,7 @@ class StubIoReactor
   end
 
   attr_reader :connections
+  attr_accessor :connection_options
 
   def initialize
     @enabled_nodes = ::Set.new


### PR DESCRIPTION
* Decrement the next protocol version to try based on the version we used in communication, not based on the current version set in connection_options.