### PR TITLE
RUBY-169 - Ignore authenticator name when creating password authenticator

### DIFF
--- a/lib/cassandra/auth/providers/password.rb
+++ b/lib/cassandra/auth/providers/password.rb
@@ -53,17 +53,11 @@ module Cassandra
           @password = password
         end
 
-        # Returns a Password Authenticator only if
-        # `org.apache.cassandra.auth.PasswordAuthenticator` is given.
-        # @param authentication_class [String] must equal to
-        #   `org.apache.cassandra.auth.PasswordAuthenticator`
-        # @return [Cassandra::Auth::Authenticator] when `authentication_class ==
-        #    "org.apache.cassandra.auth.PasswordAuthenticator"`
-        # @return [nil] for all other values of `authentication_class`
-        def create_authenticator(authentication_class)
-          if authentication_class == PASSWORD_AUTHENTICATOR_FQCN
-            Authenticator.new(@username, @password)
-          end
+        # Returns a Password Authenticator
+        # @param authentication_class [String] ignored and deprecated
+        # @return [Cassandra::Auth::Authenticator]
+        def create_authenticator(authentication_class = nil)
+          Authenticator.new(@username, @password)
         end
 
         private

--- a/lib/cassandra/auth/providers/password.rb
+++ b/lib/cassandra/auth/providers/password.rb
@@ -54,9 +54,9 @@ module Cassandra
         end
 
         # Returns a Password Authenticator
-        # @param authentication_class [String] ignored and deprecated
+        # @param authentication_class [String] ignored
         # @return [Cassandra::Auth::Authenticator]
-        def create_authenticator(authentication_class = nil)
+        def create_authenticator(authentication_class)
           Authenticator.new(@username, @password)
         end
 

--- a/spec/cassandra/auth/providers/password_spec.rb
+++ b/spec/cassandra/auth/providers/password_spec.rb
@@ -39,7 +39,7 @@ module Cassandra
 
           it 'returns nil when the authentication class is not org.apache.cassandra.auth.PasswordAuthenticator' do
             authenticator = auth_provider.create_authenticator('org.acme.Foo')
-            authenticator.should be_nil
+            authenticator.initial_response.should == "\x00foo\x00bar"
           end
         end
       end


### PR DESCRIPTION
RUBY-169 - Ignore authenticator name when creating password authenticator.

NB: Not updating CHANGELOG because this is so under the hood that I don't think users would notice.