### PR TITLE
RUBY-182 - Move attr_boolean to its own module

### DIFF
--- a/lib/cassandra/attr_boolean.rb
+++ b/lib/cassandra/attr_boolean.rb
@@ -19,13 +19,14 @@
 # This file monkey-patches Module to have an attr_boolean method to make it easy
 # for classes to define boolean instance variables with "foo?" reader methods.
 # Inspired by http://stackoverflow.com/questions/4013591/attr-reader-with-question-mark-in-a-name
-
-class Module
-  def attr_boolean(*names)
-    names.each do |name|
-      define_method(:"#{name}?") do
-        res = instance_variable_get(:"@#{name}")
-        !res.nil? && res
+module Cassandra
+  module AttrBoolean
+    def attr_boolean(*names)
+      names.each do |name|
+        define_method(:"#{name}?") do
+          res = instance_variable_get(:"@#{name}")
+          !res.nil? && res
+        end
       end
     end
   end

--- a/lib/cassandra/cluster/options.rb
+++ b/lib/cassandra/cluster/options.rb
@@ -20,6 +20,8 @@ module Cassandra
   class Cluster
     # @private
     class Options
+      extend AttrBoolean
+
       attr_reader :auth_provider, :compressor, :connect_timeout, :credentials,
                   :heartbeat_interval, :idle_timeout, :port, :schema_refresh_delay,
                   :schema_refresh_timeout, :ssl

--- a/lib/cassandra/column_container.rb
+++ b/lib/cassandra/column_container.rb
@@ -296,6 +296,7 @@ module Cassandra
     # allowing fetchers to create keyspace, table/view, and hook them together without
     # worrying about chickens and eggs.
     # NOTE: Ignore the set request if the @keyspace is already set.
+    # rubocop:disable Style/AccessorMethodName
     def set_keyspace(keyspace)
       @keyspace = keyspace unless @keyspace
     end

--- a/lib/cassandra/errors.rb
+++ b/lib/cassandra/errors.rb
@@ -287,6 +287,8 @@ module Cassandra
       # @return [Boolean] whether actual data (as opposed to data checksum) was
       #   present in the received responses.
       attr_reader :retrieved
+      alias retrieved? retrieved
+
       # @return [Symbol] the original consistency level for the request, one of
       #   {Cassandra::CONSISTENCIES}
       attr_reader :consistency
@@ -324,10 +326,6 @@ module Cassandra
         @consistency = consistency
         @required    = required
         @received    = received
-      end
-
-      def retrieved?
-        @retrieved
       end
     end
 

--- a/lib/cassandra/protocol/cql_protocol_handler.rb
+++ b/lib/cassandra/protocol/cql_protocol_handler.rb
@@ -251,17 +251,16 @@ module Cassandra
 
       # @private
       class RequestPromise < Ione::Promise
+        extend AttrBoolean
+
         attr_reader :request, :timeout
+        attr_boolean :timed_out
 
         def initialize(request, timeout)
           @request = request
           @timeout = timeout
           @timed_out = false
           super()
-        end
-
-        def timed_out?
-          @timed_out
         end
 
         def time_out!

--- a/lib/cassandra/protocol/request.rb
+++ b/lib/cassandra/protocol/request.rb
@@ -19,15 +19,14 @@
 module Cassandra
   module Protocol
     class Request
-      attr_reader :opcode, :trace
+      extend AttrBoolean
+
+      attr_reader :opcode
+      attr_boolean :trace
 
       def initialize(opcode, trace = false)
         @opcode = opcode
         @trace = trace
-      end
-
-      def trace?
-        @trace
       end
 
       def compressable?


### PR DESCRIPTION
Fixed up some more boolean methods to use attr_boolean