### PR TITLE
RUBY-165 -- Added input validation around protocol_version cluster op…

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ the release.
 
 ## Known bugs & limitations
 
+* Specifying a `protocol_version` option of 1 or 2 in cluster options will fail with a
+  `NoHostsAvailable` error rather than a `ProtocolError` against Cassandra node versions 3.0-3.4.
 * JRuby 1.6 is not officially supported, although 1.6.8 should work.
 * Because the driver reactor is using `IO.select`, the maximum number of tcp connections allowed is 1024.
 * Because the driver uses `IO#write_nonblock`, Windows is not supported.


### PR DESCRIPTION
…tion.

* Updated README to mention that specifying v1 or v2 and contacting a 3.0-3.4 node results in a NoHostsAvailable error rather than ProtocolError.