### PR TITLE
RUBY-186 - Handle custom type columns in C* 3.x schemas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Features:
 Bug Fixes:
 * [RUBY-161] Protocol version negotiation in mixed version clusters should not fall back to v1 unless it is truly warranted.    
 * [RUBY-180] Column ordering is not deterministic in Table metadata.
+* [RUBY-185] Internal columns in static-compact and dense tables should be ignored.
+* [RUBY-186] Custom type column metadata should be parsed properly for C* 3.x schemas. 
 
 Breaking Changes:
 

--- a/lib/cassandra/cluster/schema/fetchers.rb
+++ b/lib/cassandra/cluster/schema/fetchers.rb
@@ -1280,7 +1280,7 @@ module Cassandra
             order     = column_data['clustering_order'] == 'desc' ? :desc : :asc
             if column_data['type'][0] == "'"
               # This is a custom column type.
-              type = Types.custom(column_data['type'].slice(1..-1).chomp("'"))
+              type = Types.custom(column_data['type'].slice(1, column_data['type'].length - 2))
               is_frozen = false
             else
               type, is_frozen = @type_parser.parse(column_data['type'], types)

--- a/lib/cassandra/cluster/schema/fetchers.rb
+++ b/lib/cassandra/cluster/schema/fetchers.rb
@@ -1278,7 +1278,13 @@ module Cassandra
             name      = column_data['column_name']
             is_static = column_data['kind'].to_s.casecmp('STATIC').zero?
             order     = column_data['clustering_order'] == 'desc' ? :desc : :asc
-            type, is_frozen = @type_parser.parse(column_data['type'], types)
+            if column_data['type'][0] == "'"
+              # This is a custom column type.
+              type = Types.custom(column_data['type'].slice(1..-1).chomp("'"))
+              is_frozen = false
+            else
+              type, is_frozen = @type_parser.parse(column_data['type'], types)
+            end
 
             Column.new(name, type, order, is_static, is_frozen)
           end

--- a/spec/cassandra/cluster/schema/fetchers/3.0.0-data.json
+++ b/spec/cassandra/cluster/schema/fetchers/3.0.0-data.json
@@ -272,7 +272,7 @@
       "column_name": "f2",
       "clustering_order": "none",
       "column_name_bytes": "f2",
-      "kind": "regular",
+      "kind": "static",
       "position": -1,
       "type": "int"
     },


### PR DESCRIPTION
* Updated CHANGELOG
* Added integration test.