### PR TITLE
RUBY-211 - Default max-remote-hosts-to-use for DC Aware Round Robin l…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Features:
 Bug Fixes:
 * [RUBY-214](https://datastax-oss.atlassian.net/browse/RUBY-214) Client timestamps in JRuby are not fine-grained enough, causing timestamp collisions and lost rows in C*.
 
+Breaking Changes:
+
+* The Datacenter-aware load balancing policy (Cassandra::LoadBalancing::Policies::DCAwareRoundRobin) defaults to using
+  nodes in the local DC only. In prior releases, the policy would fall back to remote nodes after exhausting local nodes.
+  Specify a positive value for `max_remote_hosts_to_use` when initializing the policy to allow remote node use. 
+
+
 # 3.0.0 rc2
 Features:
 * Add protocol_version configuration option to allow the user to force the protocol version to use for communication with nodes.

--- a/lib/cassandra/load_balancing/policies/dc_aware_round_robin.rb
+++ b/lib/cassandra/load_balancing/policies/dc_aware_round_robin.rb
@@ -62,7 +62,7 @@ module Cassandra
         include MonitorMixin
 
         def initialize(datacenter = nil,
-                       max_remote_hosts_to_use = nil,
+                       max_remote_hosts_to_use = 0,
                        use_remote_hosts_for_local_consistency = false)
           datacenter              &&= String(datacenter)
           max_remote_hosts_to_use &&= Integer(max_remote_hosts_to_use)
@@ -73,6 +73,13 @@ module Cassandra
             Util.assert(max_remote_hosts_to_use >= 0) do
               'max_remote_hosts_to_use must be nil or >= 0'
             end
+          end
+
+          # If use_remote* is true, max_remote* must be > 0
+          if use_remote_hosts_for_local_consistency
+            Util.assert(max_remote_hosts_to_use.nil? || max_remote_hosts_to_use > 0,
+                        'max_remote_hosts_to_use must be nil (meaning unlimited) or > 0 when ' \
+                        'use_remote_hosts_for_local_consistency is true')
           end
 
           @datacenter = datacenter

--- a/spec/cassandra/load_balancing/policies/dc_aware_round_robin_spec.rb
+++ b/spec/cassandra/load_balancing/policies/dc_aware_round_robin_spec.rb
@@ -23,7 +23,7 @@ module Cassandra
     module Policies
       describe(DCAwareRoundRobin) do
         let(:datacenter)                             { 'DC1' }
-        let(:max_remote_hosts_to_use)                { nil }
+        let(:max_remote_hosts_to_use)                { 0 }
         let(:use_remote_hosts_for_local_consistency) { false }
 
         let(:policy) { DCAwareRoundRobin.new(datacenter, max_remote_hosts_to_use, use_remote_hosts_for_local_consistency) }
@@ -33,6 +33,15 @@ module Cassandra
         let(:host) { Host.new('127.0.0.1', nil, nil, host_datacenter) }
 
         let(:distance) { policy.distance(host) }
+
+        describe '#constructor' do
+          let(:use_remote_hosts_for_local_consistency) { true }
+          it 'should error out if use_remmote_hosts_for_local_consistency is true and max_remote_hosts_to_use is 0' do
+            expect {
+              policy
+            }.to raise_error(ArgumentError)
+          end
+        end
 
         describe('#host_up') do
           before do
@@ -49,6 +58,7 @@ module Cassandra
             end
 
             context('and another host in remote datacenter is up') do
+              let(:max_remote_hosts_to_use)                { nil }
               let(:another_host) { Host.new('127.0.0.2', nil, nil, host_datacenter) }
 
               before do


### PR DESCRIPTION
…oad-balancing policy to 0 instead of nil, thus defaulting to not use remote nodes.