### PR TITLE
RUBY-175 - escape reserved words

### DIFF
--- a/lib/cassandra/util.rb
+++ b/lib/cassandra/util.rb
@@ -165,7 +165,10 @@ module Cassandra
       # If name only contains lower-case chars and it's not a reserved word, return it
       # as-is. Otherwise, quote.
       return name if name[LOWERCASE_REGEXP] == name && !RESERVED_WORDS.include?(name)
-      DBL_QUOT + name + DBL_QUOT
+
+      # Replace double-quotes within name with two double-quotes (if any) and surround the whole
+      # thing with double-quotes
+      DBL_QUOT + name.gsub('"', '""') + DBL_QUOT
     end
 
     def guess_type(object)

--- a/spec/cassandra/table_spec.rb
+++ b/spec/cassandra/table_spec.rb
@@ -27,6 +27,7 @@ module Cassandra
       let(:col) { double('col')}
       let(:col2) { double('col2')}
       let(:col3) { double('from')}
+      let(:quote_column) { double('"my"col"')}
       let(:options) { double('options')}
       let(:id) { 1234 }
       before do
@@ -37,16 +38,19 @@ module Cassandra
         allow(col2).to receive(:type).and_return(int)
         allow(col3).to receive(:name).and_return('from')
         allow(col3).to receive(:type).and_return(varchar)
+        allow(quote_column).to receive(:name).and_return('"my"col"')
+        allow(quote_column).to receive(:type).and_return(varchar)
         allow(options).to receive(:to_cql).and_return('opt1=value1')
       end
 
       it 'should quote keyspace, table, columns properly' do
-        t = Table.new(ks, 'mytable1', [col], [], [col2, col3], options, [], id)
+        t = Table.new(ks, 'mytable1', [col], [], [col2, col3, quote_column], options, [], id)
         expected_cql = <<-EOF
 CREATE TABLE "myks1"."mytable1" (
   col int PRIMARY KEY,
   "col2" int,
-  "from" text
+  "from" text,
+  """my""col""" text
 )
 WITH opt1=value1;
         EOF


### PR DESCRIPTION
* Also properly escape names that contain double-quotes.