### PR TITLE
RUBY-219 - SortedSet first-time initialization is unstable in a multi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Features:
 
 Bug Fixes:
+* [RUBY-219](https://datastax-oss.atlassian.net/browse/RUBY-219) Sometimes get stack trace in metadata.rb due to failure in SortedSet initialization.
 
 
 # 3.0.0 GA

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -834,6 +834,11 @@ require 'cassandra/util'
 # murmur3 hash extension
 require 'cassandra_murmur3'
 
+# SortedSet has a race condition where it does some class/global initialization when the first instance is created.
+# If this is done in a multi-threaded environment, bad things can happen. So force the initialization here,
+# when loading the C* module.
+::SortedSet.new
+
 module Cassandra
   # @private
   VOID_STATEMENT = Statements::Void.new


### PR DESCRIPTION
…-threaded environment.

* Fixed by having the C* module initialize a SortedSet upon module load (prior to multiple threads messing with SortedSet).