### PR TITLE
RUBY-241 - MaterializedView base_table returns nil sometimes

### DIFF
--- a/lib/cassandra/column_container.rb
+++ b/lib/cassandra/column_container.rb
@@ -286,13 +286,12 @@ module Cassandra
 
     # @private
     # keyspace attribute may be nil because when this object was constructed, we didn't have
-    # its keyspace constructed yet. So allow updating @keyspace if it's nil, thus
+    # its keyspace constructed yet. So allow updating @keyspace, thus
     # allowing fetchers to create keyspace, table/view, and hook them together without
     # worrying about chickens and eggs.
-    # NOTE: Ignore the set request if the @keyspace is already set.
     # rubocop:disable Style/AccessorMethodName
     def set_keyspace(keyspace)
-      @keyspace = keyspace unless @keyspace
+      @keyspace = keyspace
     end
 
     # @private

--- a/lib/cassandra/keyspace.rb
+++ b/lib/cassandra/keyspace.rb
@@ -115,7 +115,7 @@ module Cassandra
     def has_materialized_view?(name)
       # We check if the view exists *and* that its base-table is set. If base-table isn't available,
       # it will be soon, so the user can poll on this method until we return a fully-baked materialized view.
-      @views.key?(name) && @views[name].base_table
+      @views.key?(name) && !@views[name].base_table.nil?
     end
 
     # @return [Cassandra::MaterializedView, nil] a materialized view or nil


### PR DESCRIPTION
* Fixed subtle bug in setting the keyspace attribute of a view; it would only be set if the view didn't have a keyspace initially. However,
  as schema updates occur, views and tables can transfer from one keyspace to a new version of the keyspace.