### PR TITLE
RUBY-164 - don't mark host down after receiving a host_down event if …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # master
 Features:
+* Do not mark a host as down if there are active connections.
+* Update Keyspace metadata to include collection of indexes defined in the keyspace.
+* Update Table metadata to include trigger-collection and view-collection metadata.
 
 Bug Fixes:
+* [RUBY-255](https://datastax-oss.atlassian.net/browse/RUBY-255) ControlConnection.peer_ip ignores peers that are missing critical information in system.peers.
 
 # 3.0.3
 

--- a/lib/cassandra/cluster/control_connection.rb
+++ b/lib/cassandra/cluster/control_connection.rb
@@ -229,7 +229,9 @@ module Cassandra
                   refresh_schema_async_wrapper
                 end
               when 'DOWN'
-                @registry.host_down(event.address)
+                # RUBY-164: Don't mark host down if there are active connections. We have
+                # logic in connector.rb to call host_down when all connections to a node are lost,
+                # so that covers the requirement.
               when 'NEW_NODE'
                 address = event.address
 

--- a/spec/cassandra/cluster/control_connection_spec.rb
+++ b/spec/cassandra/cluster/control_connection_spec.rb
@@ -895,9 +895,8 @@ module Cassandra
                 logger.should have_received(:debug).with(/Event received EVENT STATUS_CHANGE DOWN/)
               end
 
-              it 'notifies registry' do
-                ip = address.to_s
-                expect(cluster_registry).to receive(:host_down).once.with(ip)
+              it 'does not notify registry' do
+                expect(cluster_registry).to_not receive(:host_down)
                 connections.first.trigger_event(event)
               end
             end


### PR DESCRIPTION
…there are open connections.