### PR TITLE
RUBY-254 - beta protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Features:
 * Update Keyspace metadata to include collection of indexes defined in the keyspace.
 * Update Table metadata to include trigger-collection and view-collection metadata.
 * Added execution profiles to encapsulate a group of request execution options.
+* Added support for v5 beta protocol.
 
 Bug Fixes:
 * [RUBY-255](https://datastax-oss.atlassian.net/browse/RUBY-255) ControlConnection.peer_ip ignores peers that are missing critical information in system.peers.

--- a/lib/cassandra/cluster/connector.rb
+++ b/lib/cassandra/cluster/connector.rb
@@ -122,11 +122,8 @@ module Cassandra
                          ssl: @connection_options.ssl) do |connection|
           raise Errors::ClientError, 'Not connected, reactor stopped' unless connection
 
-          if @connection_options.nodelay?
-            connection.to_io.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
-          else
-            connection.to_io.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 0)
-          end
+          connection.to_io.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY,
+                                      @connection_options.nodelay? ? 1 : 0)
 
           Protocol::CqlProtocolHandler.new(connection,
                                            @reactor,

--- a/lib/cassandra/cluster/options.rb
+++ b/lib/cassandra/cluster/options.rb
@@ -25,7 +25,7 @@ module Cassandra
       attr_reader :auth_provider, :compressor, :connect_timeout, :credentials,
                   :heartbeat_interval, :idle_timeout, :port, :schema_refresh_delay,
                   :schema_refresh_timeout, :ssl, :custom_type_handlers
-      attr_boolean :protocol_negotiable, :synchronize_schema, :nodelay
+      attr_boolean :protocol_negotiable, :synchronize_schema, :nodelay, :allow_beta_protocol
 
       attr_accessor :protocol_version
 
@@ -46,7 +46,8 @@ module Cassandra
                      schema_refresh_timeout,
                      nodelay,
                      requests_per_connection,
-                     custom_types)
+                     custom_types,
+                     allow_beta_protocol)
         @logger                 = logger
         @protocol_version       = protocol_version
         @credentials            = credentials
@@ -61,6 +62,7 @@ module Cassandra
         @schema_refresh_delay   = schema_refresh_delay
         @schema_refresh_timeout = schema_refresh_timeout
         @nodelay                = nodelay
+        @allow_beta_protocol    = allow_beta_protocol
         @custom_type_handlers   = {}
         custom_types.each do |type_klass|
           @custom_type_handlers[type_klass.type] = type_klass
@@ -71,12 +73,14 @@ module Cassandra
         @requests_per_connection = requests_per_connection
 
         # If @protocol_version is nil, it means we want the driver to negotiate the
-        # protocol starting with our known max (4). If @protocol_version is not nil,
+        # protocol starting with our known max. If @protocol_version is not nil,
         # it means the user wants us to use a particular version, so we should not
         # support negotiation.
 
         @protocol_negotiable = @protocol_version.nil?
-        @protocol_version ||= 4
+        @protocol_version ||= allow_beta_protocol ?
+            Cassandra::Protocol::Versions::BETA_VERSION :
+            Cassandra::Protocol::Versions::MAX_SUPPORTED_VERSION
       end
 
       def compression

--- a/lib/cassandra/driver.rb
+++ b/lib/cassandra/driver.rb
@@ -141,13 +141,15 @@ module Cassandra
         schema_refresh_timeout,
         nodelay,
         requests_per_connection,
-        custom_types
+        custom_types,
+        allow_beta_protocol
       )
     end
 
     let(:custom_types)      { [] }
     let(:port)                      { 9042 }
     let(:protocol_version)          { nil }
+    let(:allow_beta_protocol)       { false }
     let(:connect_timeout)           { 10 }
     let(:ssl)                       { false }
     let(:logger)                    { NullLogger.new }

--- a/lib/cassandra/errors.rb
+++ b/lib/cassandra/errors.rb
@@ -348,6 +348,9 @@ module Cassandra
       attr_reader :received
       # @return [Integer] the number of writes failed
       attr_reader :failed
+      # @return [Hash<IPAddr, Integer>] map of <ip, error-code>. This is new in v5 and is nil in previous versions
+      #    of the Casssandra protocol.
+      attr_reader :failures_by_node
 
       # @private
       def initialize(message,
@@ -363,7 +366,8 @@ module Cassandra
                      consistency,
                      required,
                      failed,
-                     received)
+                     received,
+                     failures_by_node)
         super(message,
               payload,
               warnings,
@@ -378,6 +382,7 @@ module Cassandra
         @required    = required
         @failed      = failed
         @received    = received
+        @failures_by_node = failures_by_node
       end
     end
 
@@ -400,6 +405,9 @@ module Cassandra
       attr_reader :received
       # @return [Integer] the number of reads failed
       attr_reader :failed
+      # @return [Hash<IPaddr, Integer>] map of <ip, error-code>. This is new in v5 and is nil in previous versions
+      #    of the Casssandra protocol.
+      attr_reader :failures_by_node
 
       # @private
       def initialize(message,
@@ -415,7 +423,8 @@ module Cassandra
                      consistency,
                      required,
                      failed,
-                     received)
+                     received,
+                     failures_by_node)
         super(message,
               payload,
               warnings,
@@ -430,6 +439,7 @@ module Cassandra
         @required    = required
         @failed      = failed
         @received    = received
+        @failures_by_node = failures_by_node
       end
 
       def retrieved?

--- a/lib/cassandra/protocol.rb
+++ b/lib/cassandra/protocol.rb
@@ -49,6 +49,11 @@ module Cassandra
       SCHEMA_CHANGE_TARGET_FUNCTION  = 'FUNCTION'.freeze
       SCHEMA_CHANGE_TARGET_AGGREGATE = 'AGGREGATE'.freeze
     end
+
+    module Versions
+      BETA_VERSION = 5
+      MAX_SUPPORTED_VERSION = 4
+    end
   end
 end
 

--- a/lib/cassandra/protocol/responses/write_failure_error_response.rb
+++ b/lib/cassandra/protocol/responses/write_failure_error_response.rb
@@ -19,7 +19,7 @@
 module Cassandra
   module Protocol
     class WriteFailureErrorResponse < ErrorResponse
-      attr_reader :consistency, :received, :blockfor, :numfailures, :write_type
+      attr_reader :consistency, :received, :blockfor, :numfailures, :write_type, :failures_by_node
 
       def initialize(custom_payload,
                      warnings,
@@ -29,16 +29,21 @@ module Cassandra
                      received,
                      blockfor,
                      numfailures,
-                     write_type)
+                     write_type,
+                     failures_by_node)
         super(custom_payload, warnings, code, message)
 
         write_type.downcase!
 
-        @consistency = consistency
-        @received    = received
-        @blockfor    = blockfor
-        @numfailures = numfailures
-        @write_type  = write_type.to_sym
+        @consistency      = consistency
+        @received         = received
+        @blockfor         = blockfor
+        @write_type       = write_type.to_sym
+        @failures_by_node = failures_by_node
+
+        # If failures_by_node is set, numfailures isn't, and v.v. Set @numfailures to the size of the failure-map
+        # if numfailures is nil.
+        @numfailures = numfailures || @failures_by_node.size
       end
 
       def to_error(keyspace, statement, options, hosts, consistency, retries)
@@ -55,7 +60,8 @@ module Cassandra
                                @consistency,
                                @blockfor,
                                @numfailures,
-                               @received)
+                               @received,
+                               @failures_by_node)
       end
 
       def to_s

--- a/spec/cassandra/cluster/options_spec.rb
+++ b/spec/cassandra/cluster/options_spec.rb
@@ -22,46 +22,57 @@ def make_options(logger,
                  protocol_version,
                  connections_per_local_node,
                  connections_per_remote_node,
-                 requests_per_connection)
+                 requests_per_connection,
+                 allow_boolean_protocol)
   Cassandra::Cluster::Options.new(
       logger, protocol_version, nil, nil, nil, nil, nil, false,
       connections_per_local_node, connections_per_remote_node, 60, 30, true, 1, 10,
-      true, requests_per_connection, [])
+      true, requests_per_connection, [], allow_boolean_protocol)
 end
 
 module Cassandra
   class Cluster
     describe(Options) do
       let(:logger) { Cassandra::NullLogger.new }
+      it 'should set the protocol-version to max-supported if not in beta' do
+        expect(make_options(logger, nil, nil, nil, nil, false).
+            protocol_version).to eq(Cassandra::Protocol::Versions::MAX_SUPPORTED_VERSION)
+      end
+
+      it 'should set the protocol-version to beta version if allow-beta is true' do
+        expect(make_options(logger, nil, nil, nil, nil, true).
+            protocol_version).to eq(Cassandra::Protocol::Versions::BETA_VERSION)
+      end
+
       context :connections_per_local_node do
         it 'should return the default value for v2' do
-          expect(make_options(logger, 2, nil, nil, nil).
+          expect(make_options(logger, 2, nil, nil, nil, false).
               connections_per_local_node).to eq(2)
         end
 
         it 'should return the default value for v3' do
-          expect(make_options(logger, 3, nil, nil, nil).
+          expect(make_options(logger, 3, nil, nil, nil, false).
               connections_per_local_node).to eq(1)
         end
 
         it 'should return the user-specified value' do
-          expect(make_options(logger, 3, 12, nil, nil).
+          expect(make_options(logger, 3, 12, nil, nil, false).
               connections_per_local_node).to eq(12)
-          expect(make_options(logger, 2, 13, nil, nil).
+          expect(make_options(logger, 2, 13, nil, nil, false).
               connections_per_local_node).to eq(13)
         end
       end
 
       context :connections_per_remote_node do
         it 'should return the default value' do
-          expect(make_options(logger, 2, nil, nil, nil).
+          expect(make_options(logger, 2, nil, nil, nil, false).
               connections_per_remote_node).to eq(1)
-          expect(make_options(logger, 3, nil, nil, nil).
+          expect(make_options(logger, 3, nil, nil, nil, false).
               connections_per_remote_node).to eq(1)
         end
 
         it 'should return the user-specified value' do
-          expect(make_options(logger, 3, nil, 14, nil).
+          expect(make_options(logger, 3, nil, 14, nil, false).
               connections_per_remote_node).to eq(14)
         end
       end
@@ -71,31 +82,31 @@ module Cassandra
 
         it 'should return the default value for v2' do
           expect(logger).to_not receive(:warn)
-          expect(make_options(logger, 2, nil, nil, nil).
+          expect(make_options(logger, 2, nil, nil, nil, false).
               requests_per_connection).to eq(128)
         end
         it 'should return the default value for v3' do
           expect(logger).to_not receive(:warn)
-          expect(make_options(logger, 3, nil, nil, nil).
+          expect(make_options(logger, 3, nil, nil, nil, false).
               requests_per_connection).to eq(1024)
         end
         it 'should return the user-specified value' do
           expect(logger).to_not receive(:warn)
-          expect(make_options(logger, 2, nil, nil, 13).
+          expect(make_options(logger, 2, nil, nil, 13, false).
               requests_per_connection).to eq(13)
-          expect(make_options(logger, 3, nil, nil, 14).
+          expect(make_options(logger, 3, nil, nil, 14, false).
               requests_per_connection).to eq(14)
         end
 
         it 'should pull down the value to 128 if requested value is too high for v2' do
           expect(logger).to receive(:warn)
-          expect(make_options(logger, 2, nil, nil, 150).
+          expect(make_options(logger, 2, nil, nil, 150, false).
               requests_per_connection).to eq(128)
         end
 
         it 'should not adjust high value for v3' do
           expect(logger).to_not receive(:warn)
-          expect(make_options(logger, 3, nil, nil, 150).
+          expect(make_options(logger, 3, nil, nil, 150, false).
               requests_per_connection).to eq(150)
         end
       end

--- a/spec/cassandra_spec.rb
+++ b/spec/cassandra_spec.rb
@@ -399,10 +399,24 @@ describe Cassandra do
       expect { C.validate(protocol_version: 'a') }.to raise_error(ArgumentError)
       expect { C.validate(protocol_version: 0) }.to raise_error(ArgumentError)
       expect { C.validate(protocol_version: 1.5) }.to raise_error(ArgumentError)
-      expect { C.validate(protocol_version: 5) }.to raise_error(ArgumentError)
+      expect { C.validate(protocol_version: Cassandra::Protocol::Versions::MAX_SUPPORTED_VERSION + 1) }.
+          to raise_error(ArgumentError)
       expect(C.validate(protocol_version: 1)).to eq({ protocol_version: 1 })
-      expect(C.validate(protocol_version: 4)).to eq({ protocol_version: 4 })
+      expect(C.validate(protocol_version: Cassandra::Protocol::Versions::MAX_SUPPORTED_VERSION)).
+          to eq({ protocol_version: Cassandra::Protocol::Versions::MAX_SUPPORTED_VERSION })
       expect(C.validate(protocol_version: nil)).to eq({ protocol_version: nil })
+    end
+
+    it 'should validate that :protocol_version and :allow_beta_protocol are not both specified' do
+      expect(C.validate(allow_beta_protocol: true)).to eq({ allow_beta_protocol: true } )
+      expect(C.validate(allow_beta_protocol: false)).to eq({ allow_beta_protocol: false } )
+      expect { C.validate(allow_beta_protocol: true, protocol_version: 3) }.to raise_error(ArgumentError)
+      expect(C.validate(allow_beta_protocol: false, protocol_version: 3)).
+          to eq({ allow_beta_protocol: false, protocol_version: 3 })
+      expect(C.validate(allow_beta_protocol: true, protocol_version: nil)).
+          to eq({ allow_beta_protocol: true, protocol_version: nil })
+      expect(C.validate(allow_beta_protocol: false, protocol_version: nil)).
+          to eq({ allow_beta_protocol: false, protocol_version: nil })
     end
 
     it 'should validate :futures_factory option' do

--- a/support/ccm.rb
+++ b/support/ccm.rb
@@ -721,7 +721,7 @@ module CCM extend self
       ccm_node_conf_dir = "~/.ccm/ruby-driver-cassandra-#{CCM.cassandra_version}-test-cluster"
 
       (1..@nodes.size).each do |n|
-        `mkdir #{ccm_node_conf_dir}/node#{n}/conf/triggers`
+        `mkdir -p #{ccm_node_conf_dir}/node#{n}/conf/triggers`
         `cp #{trigger_root}/AuditTrigger.properties #{ccm_node_conf_dir}/node#{n}/conf`
         `cp #{trigger_root}/trigger-example.jar #{ccm_node_conf_dir}/node#{n}/conf/triggers`
       end
@@ -949,10 +949,13 @@ module CCM extend self
   def create_cluster(name, version, datacenters, nodes_per_datacenter)
     nodes = Array.new(datacenters, nodes_per_datacenter).join(':')
 
-    create_args = ['-v', version, name]
-    create_args << '--dse' if @dse
-
-    ccm.exec('create', *create_args)
+    if !@dse && ENV['CASSANDRA_DIR'] && !ENV['CASSANDRA_DIR'].empty?
+      ccm.exec('create', name, '--install-dir', ENV['CASSANDRA_DIR'])
+    else
+      create_args = ['-v', version, name]
+      create_args << '--dse' if @dse
+      ccm.exec('create', *create_args)
+    end
 
     config = [
       '--rt', '1000',


### PR DESCRIPTION
* Added allow_beta_protocol option to Cassandra.cluster
* Added handling for v5 versions of read-failure and write-failure responses.
* Added ability to run integration tests against a C* cluster using a locally build C* tree.