### PR TITLE
fixup a few ruby warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /venv
 /lib/cassandra_murmur3.*
 /node_modules
+/*.gem
+/.bundle/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,18 +5,30 @@
 All code has bugs, but if you report them they can be squashed.
 
 The best bug reports include everything that is needed to reliably reproduce the bug.
+
+### Running the Test Suite
+
 Try to write a test case and include it in your report (have a look at the
-[regression test suite](spec/integration/regression_spec.rb) if you need inspiration).
-Submit defect reports to our [Jira](https://datastax-oss.atlassian.net/projects/RUBY/issues).
+[regression test suite](spec/regressions) if you need inspiration).
+
+1. Bundle with `bundle install`
+1. Run the unit test suite with `rake rspec`
+  * Using this rake task will install necessary ruby extensions as a prerequisite
+  * For `bundle exec rspec` to be successful, run `bundle exec rake compile` once, beforehand
 
 If it's not possible to write a test case, for example because the bug only happens in
-very particular circumstances, or is not deterministic, make sure you include as much
-information as you can about the situation. The version of the ruby driver is an absolute
-must, the version of Ruby and Cassandra are also very important. If there is a stack trace
-from the error make sure to include that (unfortunately the asynchronous nature of the
-ruby driver means that the stack traces are not always as revealing as they could be).
+very particular circumstances, or is not deterministic, please still report the bug!
 
-##Pull Requests
+### Opening a ticket
+
+Submit defect reports to our [Jira](https://datastax-oss.atlassian.net/projects/RUBY/issues). Include:
+
+* The `cassandra-driver` version (`bundle exec gem cassandra-driver -v`)
+* The Ruby version (`ruby -v`)
+* The Cassandra version (2nd line printed when running `cqlsh`)
+* A stack trace from the error, if there is one
+
+## Pull Requests
 
 If you're able to fix a bug yourself, you can
 [fork the repository](https://help.github.com/articles/fork-a-repo/) and submit a

--- a/lib/cassandra/cluster/control_connection.rb
+++ b/lib/cassandra/cluster/control_connection.rb
@@ -36,8 +36,10 @@ module Cassandra
         @address_resolver      = address_resolution_policy
         @connector             = connector
         @connection_options    = connection_options
+        @connection            = nil
         @schema_fetcher        = schema_fetcher
         @refreshing_statuses   = ::Hash.new(false)
+        @refresh_schema_future = nil
         @status                = :closed
         @refreshing_hosts      = false
         @refreshing_host       = ::Hash.new(false)

--- a/lib/cassandra/executors.rb
+++ b/lib/cassandra/executors.rb
@@ -43,8 +43,8 @@ module Cassandra
         @cond    = new_cond
         @tasks   = ::Array.new
         @waiting = 0
-        @pool    = ::Array.new(size, &method(:spawn_thread))
         @term    = false
+        @pool    = ::Array.new(size, &method(:spawn_thread))
       end
 
       def execute(*args, &block)

--- a/lib/cassandra/uuid/generator.rb
+++ b/lib/cassandra/uuid/generator.rb
@@ -49,9 +49,10 @@ module Cassandra
                      clock = ::Time)
         raise ::ArgumentError, 'invalid clock' unless clock.respond_to?(:now)
 
-        @node_id  = Integer(node_id)
-        @clock_id = Integer(clock_id)
-        @clock    = clock
+        @node_id    = Integer(node_id)
+        @clock_id   = Integer(clock_id)
+        @clock      = clock
+        @last_usecs = nil
       end
 
       # Returns a new UUID with a time component that is the current time.
@@ -82,6 +83,7 @@ module Cassandra
       def now
         now   = @clock.now
         usecs = now.to_i * 1_000_000 + now.usec
+
         if @last_usecs && @last_usecs - @sequence <= usecs && usecs <= @last_usecs
           @sequence += 1
         elsif @last_usecs && @last_usecs > usecs
@@ -90,6 +92,7 @@ module Cassandra
         else
           @sequence = 0
         end
+
         @last_usecs = usecs + @sequence
         from_usecs(@last_usecs)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,9 @@ require 'support/fake_cluster_registry'
 require 'support/stub_io_reactor'
 
 RSpec.configure do |config|
+  # suppress ruby warnings
+  config.warnings = false
+
   config.expect_with(:rspec) do |c|
     c.syntax = [:should, :expect]
   end


### PR DESCRIPTION
We author a gem that has the ruby-driver as a dependency.

These are fixups for a few of the warnings that are are most repeatedly reported when we run our suite.

Happy to hear y'alls thoughts if we're being pedantic here, but we try to run our unit suite with warnings enabled to help fight entropy.