### PR TITLE
RUBY-291 - Driver fails to connect to cluster when a table column typ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-master
+# 3.1.1
 
 Features:
 
 Bug Fixes:
+* [RUBY-291](https://datastax-oss.atlassian.net/browse/RUBY-291) Driver fails to connect to cluster when a table column type has a quoted name.
 
 # 3.1.0
 Features:

--- a/lib/cassandra/cluster/schema/cql_type_parser.rb
+++ b/lib/cassandra/cluster/schema/cql_type_parser.rb
@@ -100,7 +100,7 @@ module Cassandra
             when ' '
               next
             else
-              node.name << char
+              node.name << char unless char == '"'
             end
           end
 


### PR DESCRIPTION
…e has a quoted name.

* Fixed defect in parsing schema metadata that contained quotes in column type names.