### PR TITLE
Ruby 2.4 compatible integer type guessing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,8 @@ GEM
     ffi (1.9.10-java)
     gherkin (3.2.0)
     ione (1.2.4)
-    json (1.8.3)
-    json (1.8.3-java)
+    json (1.8.6)
+    json (1.8.6-java)
     lz4-ruby (0.3.3)
     lz4-ruby (0.3.3-java)
     minitest (4.7.5)
@@ -121,4 +121,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/lib/cassandra/util.rb
+++ b/lib/cassandra/util.rb
@@ -174,9 +174,8 @@ module Cassandra
     def guess_type(object)
       case object
       when ::String      then Types.varchar
-      when ::Fixnum      then Types.bigint
+      when ::Integer     then object.size > 8 ? Types.varint : Types.bigint
       when ::Float       then Types.double
-      when ::Bignum      then Types.varint
       when ::BigDecimal  then Types.decimal
       when ::TrueClass   then Types.boolean
       when ::FalseClass  then Types.boolean

--- a/spec/cassandra/util_spec.rb
+++ b/spec/cassandra/util_spec.rb
@@ -1,0 +1,48 @@
+# encoding: utf-8
+
+#--
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require 'spec_helper'
+
+module Cassandra
+  describe Util do
+    describe '.guess_type' do
+      specs = [
+        [Types.text, 'test'],
+        [Types.varint, 2**64],
+        [Types.bigint, 2**63],
+        [Types.boolean, true],
+        [Types.boolean, false],
+        [Types.decimal, ::BigDecimal.new('1042342234234.123423435647768234')],
+        [Types.double, 10000.123123123],
+        [Types.inet, ::IPAddr.new('8.8.8.8')],
+        [Types.uuid, Uuid.new(::SecureRandom.hex)],
+        [Types.uuid, TimeUuid.new(::SecureRandom.hex)],
+        [Types.timestamp, ::Time.now],
+        [Types.map(Types.text, Types.bigint), { 'text' => 0 }],
+        [Types.list(Types.varint), [2**64]],
+        [Types.set(Types.bigint), Set.new([0])],
+      ]
+
+      specs.each do |expected_type, value|
+        it "returns #{expected_type} for #{value}" do
+          expect(Util.guess_type(value)).to eq(expected_type)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixnum and Bignum classes were unified to a single integer class in Ruby 2.4. All integers in Ruby 2.4 would match to ::Fixnum. For proper type guessing, the size of the number needs to be inspected.

Fixes [RUBY-294](https://datastax-oss.atlassian.net/browse/RUBY-294).