### PR TITLE
Remove custom message on options assertion

### DIFF
--- a/lib/cassandra/session.rb
+++ b/lib/cassandra/session.rb
@@ -243,7 +243,7 @@ module Cassandra
     # @private
     def merge_execution_options(options)
       if options
-        Util.assert_instance_of(::Hash, options, "options must be a Hash, #{options.inspect} given")
+        Util.assert_instance_of(::Hash, options)
         # Yell if the caller gave us a bad profile name.
         execution_profile = nil
         if options.key?(:execution_profile)


### PR DESCRIPTION
The custom message on asserting that options are a hash gets invoked on every query execution when options are supplied. This can add up to quite a lot of Hash.inspect calls that don't ever do anything if you use options on your queries.

Since this is just an assertion failure message, I think it would be better to just go with the default message (which is nearly identical) rather than adding the additional overhead.