### PR TITLE
Fix a case sensitivity issue when fetching the clustering order

### DIFF
--- a/lib/cassandra/cluster/schema/fetchers.rb
+++ b/lib/cassandra/cluster/schema/fetchers.rb
@@ -1361,7 +1361,7 @@ module Cassandra
           def create_column(column_data, types)
             name      = column_data['column_name']
             is_static = column_data['kind'].to_s.casecmp('STATIC').zero?
-            order     = column_data['clustering_order'] == 'desc' ? :desc : :asc
+            order     = column_data['clustering_order'].to_s.casecmp('DESC').zero? ? :desc : :asc
             if column_data['type'][0] == "'"
               # This is a custom column type.
               type = Types.custom(column_data['type'].slice(1, column_data['type'].length - 2))


### PR DESCRIPTION
I discovered this issue when using the driver with a Scylla database, which is supposed to use the same protocol. Scylla returns `DESC` instead of `desc`. So I think this fix could handle both cases.