### PR TITLE
pass through logger to CqlProtocolHandler; log information about heartbeats; send heartbeats even if one fails

### DIFF
--- a/lib/cassandra/cluster/connector.rb
+++ b/lib/cassandra/cluster/connector.rb
@@ -126,8 +126,10 @@ module Cassandra
                                       @connection_options.nodelay? ? 1 : 0)
 
           Protocol::CqlProtocolHandler.new(connection,
+                                           host,
                                            @reactor,
                                            @connection_options.protocol_version,
+                                           @logger,
                                            @connection_options.compressor,
                                            @connection_options.heartbeat_interval,
                                            @connection_options.idle_timeout,

--- a/lib/cassandra/protocol/cql_protocol_handler.rb
+++ b/lib/cassandra/protocol/cql_protocol_handler.rb
@@ -41,8 +41,10 @@ module Cassandra
       attr_reader :protocol_version
 
       def initialize(connection,
+                     host,
                      scheduler,
                      protocol_version,
+                     logger,
                      compressor = nil,
                      heartbeat_interval = 30,
                      idle_timeout = 60,
@@ -50,10 +52,12 @@ module Cassandra
                      custom_type_handlers = {})
         @protocol_version = protocol_version
         @connection = connection
+        @host = host
         @scheduler = scheduler
         @compressor = compressor
         @connection.on_data(&method(:receive_data))
         @connection.on_closed(&method(:socket_closed))
+        @logger = logger
 
         @streams = Array.new(requests_per_connection) {|i| i}
 
@@ -414,7 +418,8 @@ module Cassandra
         end
 
         timer.on_value do
-          send_request(HEARTBEAT, nil, false).on_value do
+          @logger.debug("sending heartbeat to #{@host}")
+          send_request(HEARTBEAT, nil, false).on_complete do
             schedule_heartbeat
           end
         end
@@ -432,6 +437,7 @@ module Cassandra
         end
 
         timer.on_value do
+          @logger.warning("#{@host} has had no activity in the last #{@idle_timeout}s; marking as failed")
           @terminate = nil
           @connection.close(TERMINATED)
         end


### PR DESCRIPTION
We're seeing some odd issues with the control connection dropping out due to missing the idle timeout.

This passes through the logger and logs a bit about heartbeats and timeouts.

It also changes heartbeats to be emitted even if one fails by changing from `on_value` (which is only invoked if the future succeeds) to `on_complete` (which is always invoked).