### PR TITLE
fix time encoding

### DIFF
--- a/lib/cassandra/util.rb
+++ b/lib/cassandra/util.rb
@@ -116,7 +116,7 @@ module Cassandra
     alias encode encode_object
 
     def encode_time(time, io = StringIO.new)
-      encode_string(time.to_s, io)
+      encode_string(time.strftime('%Y-%m-%d %H:%M:%S.%L%z'), io)
     end
 
     def encode_udt(udt, io = StringIO.new)


### PR DESCRIPTION
The default Ruby `.to_s` method for a Time results in output of `%Y-%m-%d %H:%M:%S %z`; note the space between the seconds and the time offset.

In Cassandra 4.0, the validator for the `TIMESTAMP` column type is stricter and there cannot be a space between the fractional part and the timezone offset and it must match the format `yyyy-mm-dd[(T| )HH:MM:SS[.fff]][(+|-)NNNN]`.