### PR TITLE
Add varchar to Cassandra::Types.text mapping

### DIFF
--- a/lib/cassandra/cluster/schema/cql_type_parser.rb
+++ b/lib/cassandra/cluster/schema/cql_type_parser.rb
@@ -42,6 +42,7 @@ module Cassandra
         def lookup_type(node, types)
           case node.name
           when 'text'              then Cassandra::Types.text
+          when 'varchar'           then Cassandra::Types.text
           when 'blob'              then Cassandra::Types.blob
           when 'ascii'             then Cassandra::Types.ascii
           when 'bigint'            then Cassandra::Types.bigint


### PR DESCRIPTION
Azure CosmosDB's cassandra returns `varchar` as a type for `text` fields.
This commit allows the `CqlTypeParser` to successfully read `varchar` fields as `text`.