### PR TITLE
use monotonic time instead of system time for timers in the IoReactor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     cassandra-driver (3.2.5)
-      ione (~> 1.2)
+      ione (~> 1.2.5)
+      monotime (~> 0.7)
 
 GEM
   remote: https://rubygems.org/
@@ -40,12 +41,13 @@ GEM
     ffi (1.9.25)
     ffi (1.9.25-java)
     gherkin (3.2.0)
-    ione (1.2.4)
+    ione (1.2.5)
     json (1.8.6)
     json (1.8.6-java)
     lz4-ruby (0.3.3)
     lz4-ruby (0.3.3-java)
     minitest (4.7.5)
+    monotime (0.7.1)
     multi_json (1.11.2)
     multi_test (0.1.2)
     os (0.9.6)

--- a/cassandra-driver.gemspec
+++ b/cassandra-driver.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |s|
     s.files << 'ext/cassandra_murmur3/cassandra_murmur3.c'
   end
 
-  s.add_runtime_dependency 'ione', '~> 1.2'
+  s.add_runtime_dependency 'ione', '~> 1.2.5'
+  s.add_runtime_dependency 'monotime', '~> 0.7'
 
   s.add_development_dependency 'bundler', '~> 1.6'
   s.add_development_dependency 'rake', '~> 13.0'

--- a/lib/cassandra/driver.rb
+++ b/lib/cassandra/driver.rb
@@ -28,7 +28,8 @@ module Cassandra
       define_method(:"#{name}=") { |object| @instances[name] = object }
     end
 
-    let(:io_reactor)       { Ione::Io::IoReactor.new }
+    let(:monotonic_clock)  { Cassandra::Util::MonoClock::new }
+    let(:io_reactor)       { Ione::Io::IoReactor.new(clock: monotonic_clock) }
     let(:cluster_registry) { Cluster::Registry.new(logger) }
     let(:cluster_schema)   { Cluster::Schema.new }
     let(:cluster_metadata) do

--- a/lib/cassandra/util.rb
+++ b/lib/cassandra/util.rb
@@ -19,6 +19,16 @@
 module Cassandra
   # @private
   module Util
+    class MonoClock
+      def initialize
+        @start = Monotime::Instant.now
+      end
+
+      def now
+        @start.elapsed.to_secs
+      end
+    end
+
     module_function
 
     def encode_hash(hash, io = StringIO.new)


### PR DESCRIPTION
This prevents strange timeouts around leap seconds (if you're not using a splaying ntp server), and also allows you to use this driver along with tools like Timecop in testing, since Timecop manipulates `Time` but not `Monotime`.

This adds a new dependency (https://github.com/Freaky/monotime), which has a minimum-supported Ruby version of 2.5. Given that everything before Ruby 2.7 is EOL already anyway, this seems okay, but there might be some value in changing the README for ruby-driver and the testing to reflect modern versions of Ruby.